### PR TITLE
Preserve paragraph ID mapping during transient Lexical sync mismatch

### DIFF
--- a/apps/desktop/src/renderer/components/EditorPane.logic.test.ts
+++ b/apps/desktop/src/renderer/components/EditorPane.logic.test.ts
@@ -33,4 +33,21 @@ describe('EditorPane lexical helpers', () => {
 
     expect(orderedIds).toBeNull();
   });
+
+  it('keeps previous key/id mapping when node count is temporarily unsynced', () => {
+    const previousKeyToId = new Map([
+      ['k_a', 'p_01'],
+      ['k_b', 'p_02'],
+      ['k_c', 'p_03'],
+    ]);
+
+    const orderedIds = mapParagraphIdsByNodeKeys(
+      ['k_a', 'k_new', 'k_b', 'k_c'],
+      ['k_c', 'k_a', 'k_new', 'k_b'],
+      ['p_01', 'p_02', 'p_03'],
+      previousKeyToId,
+    );
+
+    expect(orderedIds).toEqual(['p_03', 'p_01', 'p_02']);
+  });
 });

--- a/apps/desktop/src/renderer/components/EditorPane.tsx
+++ b/apps/desktop/src/renderer/components/EditorPane.tsx
@@ -57,29 +57,38 @@ export function mapParagraphIdsByNodeKeys(
   currentNodeKeys: string[],
   nextNodeKeys: string[],
   paragraphIds: string[],
+  previousKeyToId: ReadonlyMap<string, string> = new Map(),
 ): string[] | null {
-  if (currentNodeKeys.length !== paragraphIds.length) {
-    return null;
+  const keyToId = new Map(previousKeyToId);
+  if (currentNodeKeys.length === paragraphIds.length) {
+    keyToId.clear();
+    currentNodeKeys.forEach((nodeKey, index) => {
+      const paragraphId = paragraphIds[index];
+      if (paragraphId) {
+        keyToId.set(nodeKey, paragraphId);
+      }
+    });
   }
 
-  const keyToId = new Map<string, string>();
-  currentNodeKeys.forEach((nodeKey, index) => {
-    const paragraphId = paragraphIds[index];
-    if (paragraphId) {
-      keyToId.set(nodeKey, paragraphId);
+  const rankById = new Map<string, number>();
+  nextNodeKeys.forEach((nodeKey, index) => {
+    const paragraphId = keyToId.get(nodeKey);
+    if (paragraphId && !rankById.has(paragraphId)) {
+      rankById.set(paragraphId, index);
     }
   });
 
-  const orderedIds: string[] = [];
-  for (const nodeKey of nextNodeKeys) {
-    const paragraphId = keyToId.get(nodeKey);
-    if (!paragraphId) {
-      return null;
-    }
-    orderedIds.push(paragraphId);
+  if (rankById.size === 0) {
+    return null;
   }
 
-  return orderedIds;
+  return [...paragraphIds]
+    .map((paragraphId, index) => ({
+      paragraphId,
+      sortRank: rankById.get(paragraphId) ?? nextNodeKeys.length + index,
+    }))
+    .sort((left, right) => left.sortRank - right.sortRank)
+    .map((item) => item.paragraphId);
 }
 
 function ParagraphStatePlugin({
@@ -216,10 +225,31 @@ export function EditorPane({
   const [lastSyncedSignature, setLastSyncedSignature] = useState(() => toTextSyncSignature(getInitialParagraphTexts(document)));
   const editorRef = useRef<LexicalEditor | null>(null);
   const paragraphNodeKeysRef = useRef<string[]>([]);
+  const paragraphIdByNodeKeyRef = useRef<Map<string, string>>(new Map());
 
   useEffect(() => {
     paragraphNodeKeysRef.current = paragraphNodeKeys;
   }, [paragraphNodeKeys]);
+
+  useEffect(() => {
+    if (!document) {
+      paragraphIdByNodeKeyRef.current = new Map();
+      return;
+    }
+
+    if (paragraphNodeKeys.length !== document.paragraphs.length) {
+      return;
+    }
+
+    paragraphIdByNodeKeyRef.current = new Map(
+      paragraphNodeKeys
+        .map((nodeKey, index) => {
+          const paragraphId = document.paragraphs[index]?.id;
+          return paragraphId ? ([nodeKey, paragraphId] as const) : null;
+        })
+        .filter((entry): entry is readonly [string, string] => Boolean(entry)),
+    );
+  }, [document, paragraphNodeKeys]);
 
   useEffect(() => {
     const nextTexts = getInitialParagraphTexts(document);
@@ -327,6 +357,7 @@ export function EditorPane({
       currentKeys,
       nextKeys,
       document.paragraphs.map((paragraph) => paragraph.id),
+      paragraphIdByNodeKeyRef.current,
     );
     if (orderedIds) {
       onReorderParagraphs?.(orderedIds);


### PR DESCRIPTION
### Motivation
- Drag reorders could be dropped when Lexical node-key count and `document.paragraphs` count briefly diverge (due to the 120ms debounced text sync), allowing a later debounced replace to reapply content by index and misattach text/analysis to the wrong paragraph IDs.
- The intent is to keep `onReorderParagraphs` able to produce a stable ordered ID list even during short-lived node/paragraph count mismatches so content and analysis remain bound to correct IDs.

### Description
- Extended `mapParagraphIdsByNodeKeys` to accept a `previousKeyToId` fallback map and to compute a deterministic ordered ID list by ranking known IDs from reordered node keys instead of immediately returning `null` when counts differ.
- Added `paragraphIdByNodeKeyRef` to `EditorPane` and populate it only when node-key and paragraph counts are in sync, so a last-stable nodeKey→paragraphId mapping is available during transient mismatch windows.
- Wired the fallback map into the reorder path (`onDropReorder`) so `onReorderParagraphs` receives a stable `string[]` of paragraph IDs when possible.
- Updated tests in `EditorPane.logic.test.ts` to reflect the fallback behavior and added a regression test that simulates temporary unsynced node counts.

### Testing
- Ran `pnpm --filter @litelizard/desktop test -- EditorPane.logic.test.ts` and the test file completed successfully with all tests passing (`5 passed`).
- The updated logic tests now cover both the normal mapping case and the transient-unsynced fallback scenario and passed in CI-local test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c30af64588320a8d0c466b5e11537)