### PR TITLE
fix: ExplorerPane の selectedFolderPath 設計修正

### DIFF
--- a/apps/desktop/src/renderer/components/ExplorerPane.tsx
+++ b/apps/desktop/src/renderer/components/ExplorerPane.tsx
@@ -164,21 +164,15 @@ export function ExplorerPane({
 }: Props) {
   const [expanded, setExpanded] = useState<Set<string> | null>(null);
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
-  const [quickCreateOpen, setQuickCreateOpen] = useState(false);
+  const [selectedFolderPath, setSelectedFolderPath] = useState<string | null>(null);
 
   const defaultExpanded = useMemo(() => new Set(collectDirectoryPaths(tree)), [tree]);
   const expandedFolders = expanded ?? defaultExpanded;
 
   useEffect(() => {
-    const close = () => {
-      setContextMenu(null);
-      setQuickCreateOpen(false);
-    };
-
+    const close = () => setContextMenu(null);
     window.addEventListener('click', close);
-    return () => {
-      window.removeEventListener('click', close);
-    };
+    return () => window.removeEventListener('click', close);
   }, []);
 
   const toggleFolder = (path: string) => {
@@ -193,6 +187,31 @@ export function ExplorerPane({
       return next;
     });
   };
+
+  const handleFileClick = (path: string) => {
+    onSelectFile(path);
+  };
+
+  // currentFilePath が変わったとき（自動展開・ファイルクリック・新規作成後）に sync
+  useEffect(() => {
+    if (currentFilePath) {
+      setSelectedFolderPath(dirName(currentFilePath));
+    }
+  }, [currentFilePath]);
+
+  // rootPath 変更時にリセット
+  useEffect(() => {
+    setSelectedFolderPath(null);
+  }, [rootPath]);
+
+  // tree 更新後にパス存在チェック → rootPath へフォールバック
+  useEffect(() => {
+    if (selectedFolderPath === null) return;
+    const dirs = new Set(collectDirectoryPaths(tree));
+    if (!dirs.has(selectedFolderPath) && selectedFolderPath !== rootPath) {
+      setSelectedFolderPath(rootPath);
+    }
+  }, [tree, selectedFolderPath, rootPath]);
 
   const openCreatePrompt = (parentPath: string, type: 'file' | 'folder') => {
     const message = type === 'file' ? '新規ファイル名' : '新規フォルダ名';
@@ -228,7 +247,6 @@ export function ExplorerPane({
 
   const onOpenContextMenu = (event: React.MouseEvent<HTMLElement>, node: FileNode) => {
     event.preventDefault();
-    setQuickCreateOpen(false);
     setContextMenu({
       x: event.clientX,
       y: event.clientY,
@@ -238,57 +256,49 @@ export function ExplorerPane({
   };
 
   const canCreate = Boolean(rootPath);
+  const createParent = selectedFolderPath ?? rootPath ?? '';
 
   return (
     <aside className="explorer-layout" style={style} data-testid="file-browser-pane">
       <div className="explorer-panel">
         <div className="explorer-panel-toolbar">
-          <div className="explorer-plus-wrap">
+          <div className="explorer-toolbar-actions">
             <button
-              className="icon-button"
-              onClick={(event) => {
-                event.stopPropagation();
-                setContextMenu(null);
-                setQuickCreateOpen((value) => !value);
-              }}
+              className="icon-button explorer-add-btn"
+              onClick={() => openCreatePrompt(createParent, 'file')}
               disabled={!canCreate}
-              title="新規作成"
+              title="新規ファイル"
+              aria-label="新規ファイル"
             >
-              ＋
+              <span className="explorer-icon-wrap"><FileIcon /><span className="explorer-add-plus">+</span></span>
             </button>
-
-            {quickCreateOpen && rootPath ? (
-              <div className="explorer-popover" onClick={(event) => event.stopPropagation()}>
-                <button
-                  className="menu-item"
-                  onClick={() => {
-                    openCreatePrompt(rootPath, 'file');
-                    setQuickCreateOpen(false);
-                  }}
-                >
-                  新規ファイル
-                </button>
-                <button
-                  className="menu-item"
-                  onClick={() => {
-                    openCreatePrompt(rootPath, 'folder');
-                    setQuickCreateOpen(false);
-                  }}
-                >
-                  新規フォルダ
-                </button>
-              </div>
-            ) : null}
+            <button
+              className="icon-button explorer-add-btn"
+              onClick={() => openCreatePrompt(createParent, 'folder')}
+              disabled={!canCreate}
+              title="新規フォルダ"
+              aria-label="新規フォルダ"
+            >
+              <span className="explorer-icon-wrap"><FolderIcon /><span className="explorer-add-plus">+</span></span>
+            </button>
           </div>
         </div>
 
-        <div className="explorer-tree" onContextMenu={(event) => event.preventDefault()}>
+        <div
+          className="explorer-tree"
+          onContextMenu={(event) => event.preventDefault()}
+          onClick={(event) => {
+            if (event.target === event.currentTarget) {
+              setSelectedFolderPath(null);
+            }
+          }}
+        >
           <Tree
             nodes={tree}
             currentFilePath={currentFilePath}
             expanded={expandedFolders}
             onToggle={toggleFolder}
-            onSelectFile={onSelectFile}
+            onSelectFile={handleFileClick}
             onOpenContextMenu={onOpenContextMenu}
           />
         </div>

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -192,11 +192,25 @@ textarea {
   color: var(--muted);
 }
 
-.explorer-plus-wrap {
-  position: relative;
+.explorer-toolbar-actions {
+  display: flex;
+  gap: 2px;
 }
 
-.explorer-popover,
+.explorer-icon-wrap {
+  position: relative;
+  display: inline-flex;
+}
+
+.explorer-add-plus {
+  position: absolute;
+  bottom: -3px;
+  right: -4px;
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 1;
+}
+
 .context-menu {
   position: fixed;
   min-width: 160px;
@@ -207,13 +221,6 @@ textarea {
   padding: 6px;
   display: grid;
   gap: 4px;
-}
-
-.explorer-popover {
-  top: calc(100% + 6px);
-  right: 0;
-  position: absolute;
-  min-width: 150px;
 }
 
 .menu-item {


### PR DESCRIPTION
## Summary

- `handleFolderClick` を廃止し `toggleFolder` を直接渡す — フォルダクリックは展開トグルのみ、作成先を上書きしない
- `currentFilePath` 変化時（ファイルクリック・自動展開・新規作成後）に `selectedFolderPath` を `useEffect` で自動 sync
- `rootPath` 変更時に `selectedFolderPath` をリセット
- `tree` 更新後（リネーム/削除後）にパス存在チェック → 無効なら `rootPath` へフォールバック
- エクスプローラー空白クリックで `selectedFolderPath = null` にリセット → ツールバー add がルート直下を作成先にする
- `handleFileClick` から `setSelectedFolderPath` を削除（読み込み失敗時に UI の選択中ファイルと作成先が乖離するバグを修正）

## 設計方針の変更点

| Before | After |
|---|---|
| フォルダクリック → `selectedFolderPath` 更新 | フォルダクリック → トグルのみ |
| — | `currentFilePath` 変化 → `selectedFolderPath` を sync |
| — | 空白クリック → `selectedFolderPath = null`（ルートへ戻る） |

フォルダを直接作成先に指定したい場合は右クリックメニューを使う。

## Test plan

- [x] 起動時に pakira.md が自動展開済み → add ボタン → ルート直下に作成される
- [x] `notes/` をトグル後 → add ボタン → **ルート直下**に作成される（トグルは影響しない）
- [x] `memo.md` をクリック → add ボタン → `notes/` 配下に作成される
- [x] `pakira.md` をクリック → add ボタン → ルート直下に作成される
- [x] 空白クリック → add ボタン → ルート直下に作成される
- [x] `notes/` を右クリック → 新規ファイル → `notes/` 配下に作成される
- [x] 選択中フォルダをリネーム/削除 → add ボタン → rootPath にフォールバックして成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)