### PR TITLE
feat(E-09): preload mock を動的 import に変更して本番バンドルから除外

### DIFF
--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -2,21 +2,28 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from './App.js';
 import './styles.css';
-import { createMockPreloadApi } from '../preload/preloadMockApi.js';
-import { mockRootPath } from '../preload/preloadMockData.js';
-import { useAppStore } from './store/useAppStore.js';
 
-if (!window.litelizard) {
-  window.litelizard = createMockPreloadApi();
-  void (async () => {
-    const { openFolder, loadDocument } = useAppStore.getState();
-    await openFolder();
-    await loadDocument(`${mockRootPath}/pakira.md`);
-  })();
+async function bootstrap() {
+  if (!window.litelizard) {
+    const { createMockPreloadApi } = await import('../preload/preloadMockApi.js');
+    const { mockRootPath } = await import('../preload/preloadMockData.js');
+    window.litelizard = createMockPreloadApi();
+
+    try {
+      const { useAppStore } = await import('./store/useAppStore.js');
+      const { openFolder, loadDocument } = useAppStore.getState();
+      await openFolder();
+      await loadDocument(`${mockRootPath}/pakira.md`);
+    } catch (error) {
+      console.error('[bootstrap] Mock initialization failed', error);
+    }
+  }
+
+  createRoot(document.getElementById('root')!).render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>
+  );
 }
 
-createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
-);
+void bootstrap();


### PR DESCRIPTION
## Summary
- `createMockPreloadApi` と `mockRootPath` の静的 import を動的 import に変更し、Electron 本番環境ではモックコードがバンドルに含まれないようにした
- `!window.litelizard` チェックによりブラウザ直アクセス時のみモック API をロード
- モック初期化（`openFolder` / `loadDocument`）を `try/catch` でガードし、失敗時も React がマウントされるよう対応

## Test plan
- [ ] ユニットテストが既存のまま通ること（worktree 環境での実行は node_modules 未インストールのためスキップ。メインリポジトリで確認）
- [ ] Electron 起動時に `window.litelizard` が preload から設定されモックコードがロードされないこと
- [ ] ブラウザ直アクセス時にモック API がロードされ初期データが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)