### PR TITLE
Implement analysis result persistence and error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+[2026/04/22]L-04 外部API解析リクエストと永続化
+テストフック除去・OpenAI/Anthropicエラー日本語化・.lzl解析結果の世代ファイル永続化（再起動後も復元）・AnalysisResult型がanyに落ちていたshared tsconfig修正
+
 [2026/04/21]L-03 Provider抽象化とcontext修正
 mainプロセスの解析実行をprovider抽象経由に切り替え、OpenAI/Anthropic切替と文書全体順序ベースのcontext構築を実装した
 

--- a/apps/desktop/src/main/analysisProvider.ts
+++ b/apps/desktop/src/main/analysisProvider.ts
@@ -1,4 +1,4 @@
-import OpenAI from 'openai';
+import OpenAI, { AuthenticationError, RateLimitError } from 'openai';
 import type { AnalysisResult, AnalysisRunInput } from '@litelizard/shared';
 import type { AnalysisProviderId, AnalysisSettings, PersonaMode } from '@litelizard/shared';
 
@@ -114,30 +114,41 @@ export function createOpenAiAnalysisProvider(apiKey: string): AnalysisProvider {
     id: 'openai',
     async analyzeParagraph(input: AnalysisProviderRequest): Promise<AnalysisResult> {
       const system = buildSystemPrompt(input.personaMode, input.contextTexts);
-      const completion = await client.responses.create({
-        model: input.model,
-        input: [
-          { role: 'system', content: system },
-          { role: 'user', content: input.text },
-        ],
-        text: {
-          format: {
-            type: 'json_schema',
-            name: 'litelizard_analysis',
-            schema: {
-              type: 'object',
-              additionalProperties: false,
-              required: ['emotion', 'theme', 'deepMeaning', 'confidence'],
-              properties: {
-                emotion: { type: 'array', items: { type: 'string' }, maxItems: 8 },
-                theme: { type: 'array', items: { type: 'string' }, maxItems: 8 },
-                deepMeaning: { type: 'string', maxLength: 1000 },
-                confidence: { type: 'number', minimum: 0, maximum: 1 },
+      let completion: Awaited<ReturnType<typeof client.responses.create>>;
+      try {
+        completion = await client.responses.create({
+          model: input.model,
+          input: [
+            { role: 'system', content: system },
+            { role: 'user', content: input.text },
+          ],
+          text: {
+            format: {
+              type: 'json_schema',
+              name: 'litelizard_analysis',
+              schema: {
+                type: 'object',
+                additionalProperties: false,
+                required: ['emotion', 'theme', 'deepMeaning', 'confidence'],
+                properties: {
+                  emotion: { type: 'array', items: { type: 'string' }, maxItems: 8 },
+                  theme: { type: 'array', items: { type: 'string' }, maxItems: 8 },
+                  deepMeaning: { type: 'string', maxLength: 1000 },
+                  confidence: { type: 'number', minimum: 0, maximum: 1 },
+                },
               },
             },
           },
-        },
-      });
+        });
+      } catch (error) {
+        if (error instanceof AuthenticationError) {
+          throw new Error('OpenAI API キーが無効です。設定画面で再入力してください。');
+        }
+        if (error instanceof RateLimitError) {
+          throw new Error('OpenAI のレート制限に達しました。しばらく待ってから再試行してください。');
+        }
+        throw error;
+      }
 
       const parsed = JSON.parse(completion.output_text) as {
         emotion?: unknown;
@@ -183,7 +194,13 @@ export function createAnthropicAnalysisProvider(apiKey: string): AnalysisProvide
 
       if (!response.ok) {
         const raw = await response.text();
-        throw new Error(`Anthropic API request failed (${response.status}): ${raw.slice(0, 200)}`);
+        if (response.status === 401) {
+          throw new Error('Anthropic API キーが無効です。設定画面で再入力してください。');
+        }
+        if (response.status === 429) {
+          throw new Error('Anthropic のレート制限に達しました。しばらく待ってから再試行してください。');
+        }
+        throw new Error(`Anthropic API エラー (${response.status}): ${raw.slice(0, 200)}`);
       }
 
       const payload = await response.json() as {

--- a/apps/desktop/src/main/apiBridge.ts
+++ b/apps/desktop/src/main/apiBridge.ts
@@ -11,10 +11,6 @@ export async function runAnalysis(
     const results: AnalysisResult[] = [];
 
     for (const paragraph of input.paragraphs) {
-      if (paragraph.text.includes('[[FAIL]]')) {
-        throw new Error('Forced failure for testing');
-      }
-
       const analyzed = await resolvedProvider.provider.analyzeParagraph({
         paragraphId: paragraph.paragraphId,
         text: paragraph.text,

--- a/apps/desktop/src/renderer/store/useAppStore.ts
+++ b/apps/desktop/src/renderer/store/useAppStore.ts
@@ -88,6 +88,10 @@ function applyAnalysisToDocument(
       const latest = history?.patterns.at(-1);
       if (!latest) return paragraph;
       const r = latest.result as Record<string, unknown>;
+      // sourceText が保存されていて現在テキストと一致しない場合は stale のまま
+      if (typeof r.sourceText === 'string' && r.sourceText !== paragraph.light.text) {
+        return paragraph;
+      }
       return {
         ...paragraph,
         lizard: {
@@ -631,6 +635,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 
       const rootPath = get().rootPath;
       if (rootPath && document.source?.format === 'lzl-v1') {
+        const staleTextMap = new Map(staleParagraphs.map((p) => [p.id, p.light.text]));
         await Promise.allSettled(
           result.results.map((analyzed) =>
             window.litelizard.saveAnalysisResult(rootPath, document.documentId, analyzed.paragraphId, {
@@ -641,6 +646,7 @@ export const useAppStore = create<AppState>((set, get) => ({
                 deepMeaning: analyzed.deepMeaning,
                 confidence: analyzed.confidence,
                 model: analyzed.model,
+                sourceText: staleTextMap.get(analyzed.paragraphId) ?? '',
               },
             })
           )
@@ -725,6 +731,7 @@ export const useAppStore = create<AppState>((set, get) => ({
                 deepMeaning: analyzed.deepMeaning,
                 confidence: analyzed.confidence,
                 model: analyzed.model,
+                sourceText: paragraph.light.text,
               },
             }),
           ]);

--- a/apps/desktop/src/renderer/store/useAppStore.ts
+++ b/apps/desktop/src/renderer/store/useAppStore.ts
@@ -5,6 +5,7 @@ import {
   type AnalysisSettings,
   type AnalysisSettingsInput,
   type FileNode,
+  type GenerationalAnalysisFile,
   type LiteLizardDocument,
 } from '@litelizard/shared';
 import type { DocumentStructureInput } from '../types/documentStructure.js';
@@ -73,6 +74,33 @@ function toAnalysisSettingsInput(settings: AnalysisSettings): AnalysisSettingsIn
       endpoint: settings.localLlm.endpoint,
       defaultModel: settings.localLlm.defaultModel,
     },
+  };
+}
+
+function applyAnalysisToDocument(
+  document: LiteLizardDocument,
+  analysisFile: GenerationalAnalysisFile,
+): LiteLizardDocument {
+  return {
+    ...document,
+    paragraphs: document.paragraphs.map((paragraph) => {
+      const history = analysisFile.paragraphs[paragraph.id];
+      const latest = history?.patterns.at(-1);
+      if (!latest) return paragraph;
+      const r = latest.result as Record<string, unknown>;
+      return {
+        ...paragraph,
+        lizard: {
+          status: 'complete' as const,
+          emotion: Array.isArray(r.emotion) ? (r.emotion as string[]) : [],
+          theme: Array.isArray(r.theme) ? (r.theme as string[]) : [],
+          deepMeaning: typeof r.deepMeaning === 'string' ? r.deepMeaning : '',
+          confidence: typeof r.confidence === 'number' ? r.confidence : 0,
+          model: typeof r.model === 'string' ? r.model : '',
+          analyzedAt: latest.analyzedAt,
+        },
+      };
+    }),
   };
 }
 
@@ -403,9 +431,23 @@ export const useAppStore = create<AppState>((set, get) => ({
   loadDocument: async (filePath: string) => {
     try {
       const document = await window.litelizard.loadDocument(filePath);
+
+      let resolvedDoc = document;
+      if (document.source?.format === 'lzl-v1') {
+        const rootPath = get().rootPath;
+        if (rootPath) {
+          const analysisFile = await window.litelizard
+            .loadAnalysis(rootPath, document.documentId, filePath)
+            .catch(() => null);
+          if (analysisFile) {
+            resolvedDoc = applyAnalysisToDocument(document, analysisFile);
+          }
+        }
+      }
+
       set({
         currentFilePath: filePath,
-        document,
+        document: resolvedDoc,
         revision: 0,
         dirty: false,
         statusMessage: 'ドキュメントを読み込みました',
@@ -587,6 +629,24 @@ export const useAppStore = create<AppState>((set, get) => ({
         }),
       };
 
+      const rootPath = get().rootPath;
+      if (rootPath && document.source?.format === 'lzl-v1') {
+        await Promise.allSettled(
+          result.results.map((analyzed) =>
+            window.litelizard.saveAnalysisResult(rootPath, document.documentId, analyzed.paragraphId, {
+              analyzedAt: analyzed.analyzedAt,
+              result: {
+                emotion: analyzed.emotion,
+                theme: analyzed.theme,
+                deepMeaning: analyzed.deepMeaning,
+                confidence: analyzed.confidence,
+                model: analyzed.model,
+              },
+            })
+          )
+        );
+      }
+
       set({
         document: {
           ...nextDoc,
@@ -607,7 +667,7 @@ export const useAppStore = create<AppState>((set, get) => ({
                   status: 'failed',
                   error: {
                     code: 'ANALYSIS_ABORTED',
-                    message: 'At least one paragraph failed. No results were applied.',
+                    message,
                   },
                 },
               }
@@ -652,6 +712,24 @@ export const useAppStore = create<AppState>((set, get) => ({
     try {
       const result = await window.litelizard.runAnalysis(payload);
       const analyzed = result.results.find((r) => r.paragraphId === paragraphId);
+
+      if (analyzed) {
+        const rootPath = get().rootPath;
+        if (rootPath && document.source?.format === 'lzl-v1') {
+          await Promise.allSettled([
+            window.litelizard.saveAnalysisResult(rootPath, document.documentId, analyzed.paragraphId, {
+              analyzedAt: analyzed.analyzedAt,
+              result: {
+                emotion: analyzed.emotion,
+                theme: analyzed.theme,
+                deepMeaning: analyzed.deepMeaning,
+                confidence: analyzed.confidence,
+                model: analyzed.model,
+              },
+            }),
+          ]);
+        }
+      }
 
       set((state) => {
         if (!state.document || !analyzed) return {};

--- a/docs/wbs.md
+++ b/docs/wbs.md
@@ -134,7 +134,7 @@
 | L-01 | API キー設定 UI（renderer: 設定画面） | E-01 ✅ | P1 | M | ✅ | Codex | |
 | L-02 | API キー暗号化保存（main: safeStorage） | E-01 ✅ | P1 | M | ✅ | | |
 | L-03 | LLM プロバイダー抽象化層（main: provider interface） | L-02 | P1 | L | ✅ | Codex | |
-| L-04 | 外部 API 方式の解析リクエスト実装（main → OpenAI/Anthropic） | L-03 | P1 | M | ⬜ | | |
+| L-04 | 外部 API 方式の解析リクエスト実装（main → OpenAI/Anthropic） | L-03 | P1 | M | ✅ | Claude | claude/next-task-F7SoK |
 | L-05 | 解析結果の IPC ストリーミング（main → renderer） | L-04, E-01 ✅ | P1 | M | ⬜ | | |
 | L-06 | 解析結果の保存・UI 反映 | L-05, E-06 ✅ | P1 | M | ⬜ | | |
 | L-07 | API キー未設定時の UI 制御（設定導線表示） | L-01 | P1 | S | ✅ | Codex | |
@@ -156,6 +156,14 @@
 - **対象**: Strategy パターンでプロバイダーを切り替え。将来のクラウド方式もこのインターフェースに乗る
 - **完了条件**: `AnalysisProvider` インターフェースが定義され、外部 API / ローカル LLM / クラウド（将来）を差し替え可能
 - **完了**: 2026-04-21。main 側に `AnalysisProvider` 抽象層と provider resolver を追加し、OpenAI / Anthropic の実行切替、未対応 provider の明示エラー、文書全体順序ベースの context 構築、関連テストを実装
+
+#### L-04: 外部 API 方式の解析リクエスト実装 ✅
+- **完了**: 2026-04-22。L-03 で実装済みだった OpenAI Responses API / Anthropic raw fetch の API 呼び出し層を検証・修正し、以下を追加実装した
+  - `apiBridge.ts`: `[[FAIL]]` テストフックを本番コードから除去
+  - `analysisProvider.ts`: OpenAI SDK の `AuthenticationError`/`RateLimitError`、Anthropic の HTTP 401/429 を日本語エラーメッセージに分類
+  - `useAppStore.ts` `loadDocument`: `.lzl` ファイルを開く際に `.litelizard/analysis/` から世代ファイルを読み込んで `lizard` フィールドに復元
+  - `useAppStore.ts` `runAnalysis`/`runAnalysisFor`: 解析成功後に `saveAnalysisResult` IPC を呼び出して結果を世代ファイルに永続化（`Promise.allSettled` で保存失敗は UI をブロックしない）
+  - `packages/shared/tsconfig.json`: `types: ["node"]` を追加し `AnalysisResult` が `any` 推論されていた問題を修正
 
 #### L-05: 解析結果の IPC ストリーミング
 - **対象**: `webContents.send` で段落ごとの分析結果を renderer に逐次送信

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -4,7 +4,8 @@
     "outDir": "dist",
     "rootDir": "src",
     "composite": true,
-    "declarationMap": true
+    "declarationMap": true,
+    "types": ["node"]
   },
   "include": ["src/**/*.ts", "../../LiteLizard_schema_v1.json"],
   "exclude": ["src/**/*.test.ts"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,8 +82,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/shared
       electron-store:
-        specifier: ^10.0.0
-        version: 10.1.0
+        specifier: ^11.0.2
+        version: 11.0.2
       lexical:
         specifier: ^0.19.0
         version: 0.19.0
@@ -1367,8 +1367,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  conf@14.0.0:
-    resolution: {integrity: sha512-L6BuueHTRuJHQvQVc6YXYZRtN5vJUtOdCTLn0tRYYV5azfbAFcPghB5zEE40mVrV6w7slMTqUfkDomutIK14fw==}
+  conf@15.1.0:
+    resolution: {integrity: sha512-Uy5YN9KEu0WWDaZAVJ5FAmZoaJt9rdK6kH+utItPyGsCqCgaTKkrmZx3zoE0/3q6S3bcp3Ihkk+ZqPxWxFK5og==}
     engines: {node: '>=20'}
 
   convert-source-map@2.0.0:
@@ -1440,9 +1440,9 @@ packages:
   detect-node@2.1.0:
     resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
 
-  dot-prop@9.0.0:
-    resolution: {integrity: sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==}
-    engines: {node: '>=18'}
+  dot-prop@10.1.0:
+    resolution: {integrity: sha512-MVUtAugQMOff5RnBy2d9N31iG0lNwg1qAoAOn7pOK5wf94WIaE3My2p3uwTQuvS2AcqchkcR3bHByjaM0mmi7Q==}
+    engines: {node: '>=20'}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -1451,8 +1451,8 @@ packages:
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
-  electron-store@10.1.0:
-    resolution: {integrity: sha512-oL8bRy7pVCLpwhmXy05Rh/L6O93+k9t6dqSw0+MckIc3OmCTZm6Mp04Q4f/J0rtu84Ky6ywkR8ivtGOmrq+16w==}
+  electron-store@11.0.2:
+    resolution: {integrity: sha512-4VkNRdN+BImL2KcCi41WvAYbh6zLX5AUTi4so68yPqiItjbgTjqpEnGAqasgnG+lB6GuAyUltKwVopp6Uv+gwQ==}
     engines: {node: '>=20'}
 
   electron-to-chromium@1.5.286:
@@ -2340,6 +2340,10 @@ packages:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
 
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
   tar-fs@2.1.4:
     resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
 
@@ -2409,9 +2413,9 @@ packages:
     resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
     engines: {node: '>=10'}
 
-  type-fest@4.41.0:
-    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
-    engines: {node: '>=16'}
+  type-fest@5.6.0:
+    resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
+    engines: {node: '>=20'}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -3792,13 +3796,13 @@ snapshots:
       tree-kill: 1.2.2
       yargs: 17.7.2
 
-  conf@14.0.0:
+  conf@15.1.0:
     dependencies:
       ajv: 8.17.1
       ajv-formats: 3.0.1(ajv@8.17.1)
       atomically: 2.1.1
       debounce-fn: 6.0.0
-      dot-prop: 9.0.0
+      dot-prop: 10.1.0
       env-paths: 3.0.0
       json-schema-typed: 8.0.2
       semver: 7.7.4
@@ -3859,9 +3863,9 @@ snapshots:
   detect-node@2.1.0:
     optional: true
 
-  dot-prop@9.0.0:
+  dot-prop@10.1.0:
     dependencies:
-      type-fest: 4.41.0
+      type-fest: 5.6.0
 
   dunder-proto@1.0.1:
     dependencies:
@@ -3873,10 +3877,10 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  electron-store@10.1.0:
+  electron-store@11.0.2:
     dependencies:
-      conf: 14.0.0
-      type-fest: 4.41.0
+      conf: 15.1.0
+      type-fest: 5.6.0
 
   electron-to-chromium@1.5.286: {}
 
@@ -4838,6 +4842,8 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  tagged-tag@1.0.0: {}
+
   tar-fs@2.1.4:
     dependencies:
       chownr: 1.1.4
@@ -4902,7 +4908,9 @@ snapshots:
   type-fest@0.13.1:
     optional: true
 
-  type-fest@4.41.0: {}
+  type-fest@5.6.0:
+    dependencies:
+      tagged-tag: 1.0.0
 
   typescript@5.9.3: {}
 


### PR DESCRIPTION
## Summary
This PR completes the external API analysis implementation (L-04) by adding persistent storage of analysis results to generational files and improving error handling for OpenAI and Anthropic API failures.

## Key Changes

- **Analysis Result Persistence**: 
  - Added `applyAnalysisToDocument()` to restore analysis results from `.litelizard/analysis/` generational files when loading `.lzl` documents
  - Modified `loadDocument()` to automatically load and apply cached analysis results on document open
  - Updated `runAnalysis()` and `runAnalysisFor()` to persist results via `saveAnalysisResult()` IPC after successful analysis

- **Error Handling**:
  - Enhanced OpenAI provider to catch `AuthenticationError` and `RateLimitError` and convert to user-friendly Japanese error messages
  - Enhanced Anthropic provider to detect HTTP 401/429 responses and provide localized error messages
  - Wrapped OpenAI API call in try-catch for proper error classification

- **Code Quality**:
  - Removed test-only `[[FAIL]]` hook from `apiBridge.ts` production code
  - Fixed `packages/shared/tsconfig.json` by adding `"types": ["node"]` to resolve `AnalysisResult` type inference issue

- **Documentation**:
  - Updated `docs/wbs.md` to mark L-04 as complete with implementation details
  - Added CHANGELOG entry documenting the changes

## Implementation Details

Analysis results are now persisted after each analysis run using `Promise.allSettled()` to ensure UI remains responsive even if persistence fails. When documents are reopened, the latest analysis results are automatically restored from the generational file structure, providing a seamless user experience across application restarts.

https://claude.ai/code/session_019fk1kqnKWe61L69HVNqkdU