### PR TITLE
feat: L-05 解析 IPC ストリーミング / R-05 .litelizard/ 非表示 / R-06 確認

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+[2026/04/23]L-05/R-05/R-06 解析ストリーミング・エクスプローラーフィルタ
+L-05: 解析を段落ごとに逐次返却するIPC ストリーミング（analysis:progressチャンネル）を実装し、UI がリアルタイムに更新されるようになった。R-05: walk()に.litelizardスキップを追加しエクスプローラーに表示されなくなった。R-06: E-06実装時にipc.tsのdeleteEntryがdeleteAnalysisFilesを呼び出す形で既に完了済みだったためWBSを更新した。
+
 [2026/04/22]L-04 外部API解析リクエストと永続化
 テストフック除去・OpenAI/Anthropicエラー日本語化・.lzl解析結果の世代ファイル永続化（再起動後も復元）・AnalysisResult型がanyに落ちていたshared tsconfig修正
 

--- a/apps/desktop/src/main/apiBridge.ts
+++ b/apps/desktop/src/main/apiBridge.ts
@@ -8,7 +8,7 @@ export async function runAnalysis(
   resolvedProvider: ResolvedAnalysisProvider,
   onProgress?: (result: AnalysisResult) => void,
 ): Promise<AnalysisRunResult> {
-  const execute = async () => {
+  const execute = async (progressCallback?: (result: AnalysisResult) => void) => {
     const results: AnalysisResult[] = [];
 
     for (const paragraph of input.paragraphs) {
@@ -20,7 +20,7 @@ export async function runAnalysis(
         model: resolvedProvider.model,
         contextTexts: buildContextTexts(input.documentParagraphs, paragraph.paragraphId),
       });
-      onProgress?.(analyzed);
+      progressCallback?.(analyzed);
       results.push(analyzed);
     }
 
@@ -34,8 +34,9 @@ export async function runAnalysis(
   };
 
   try {
-    return await execute();
+    return await execute(onProgress);
   } catch {
+    // リトライ時は onProgress を渡さない（重複発火・重複保存を防ぐ）
     return execute();
   }
 }

--- a/apps/desktop/src/main/apiBridge.ts
+++ b/apps/desktop/src/main/apiBridge.ts
@@ -6,6 +6,7 @@ import type { ResolvedAnalysisProvider } from './analysisProvider.js';
 export async function runAnalysis(
   input: AnalysisRunInput,
   resolvedProvider: ResolvedAnalysisProvider,
+  onProgress?: (result: AnalysisResult) => void,
 ): Promise<AnalysisRunResult> {
   const execute = async () => {
     const results: AnalysisResult[] = [];
@@ -19,6 +20,7 @@ export async function runAnalysis(
         model: resolvedProvider.model,
         contextTexts: buildContextTexts(input.documentParagraphs, paragraph.paragraphId),
       });
+      onProgress?.(analyzed);
       results.push(analyzed);
     }
 

--- a/apps/desktop/src/main/fileService.ts
+++ b/apps/desktop/src/main/fileService.ts
@@ -346,6 +346,7 @@ async function walk(root: string, isRoot = false): Promise<FileNode[]> {
     const absolutePath = path.join(root, entry.name);
 
     if (entry.isDirectory()) {
+      if (entry.name === '.litelizard') continue;
       const children = await walk(absolutePath);
       nodes.push({
         path: absolutePath,

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -6,6 +6,7 @@ import {
   createDocumentId,
   createParagraphId,
   IPC_CHANNELS,
+  type AnalysisProgressEvent,
   type AnalysisRunInput,
   type AnalysisSettingsInput,
   type LiteLizardDocument,
@@ -378,7 +379,7 @@ export function registerIpcHandlers() {
     }
   });
 
-  ipcMain.handle(IPC_CHANNELS.runAnalysis, async (_, input: AnalysisRunInput) => {
+  ipcMain.handle(IPC_CHANNELS.runAnalysis, async (event, input: AnalysisRunInput) => {
     const [savedSettings, secrets] = await Promise.all([
       analysisSettingsStore.load(),
       apiKeyVault.loadAll(),
@@ -388,7 +389,12 @@ export function registerIpcHandlers() {
       anthropic: Boolean(secrets.anthropic?.trim()),
     });
     const provider = resolveAnalysisProvider(analysisSettings, secrets);
-    return runAnalysis(input, provider);
+    return runAnalysis(input, provider, (result) => {
+      event.sender.send(IPC_CHANNELS.analysisProgress, {
+        paragraphId: result.paragraphId,
+        result,
+      } satisfies AnalysisProgressEvent);
+    });
   });
 
   ipcMain.handle(IPC_CHANNELS.loadAnalysis, async (_, projectRoot: string, documentId: string, filePath?: string) => {

--- a/apps/desktop/src/preload/ipcBridge.ts
+++ b/apps/desktop/src/preload/ipcBridge.ts
@@ -1,5 +1,5 @@
 import { ipcRenderer } from 'electron';
-import type { BridgeApi } from '@litelizard/shared';
+import type { AnalysisProgressEvent, BridgeApi } from '@litelizard/shared';
 import { IPC_CHANNELS } from '@litelizard/shared';
 
 export function createIpcBridge(): BridgeApi {
@@ -47,5 +47,12 @@ export function createIpcBridge(): BridgeApi {
       ipcRenderer.invoke(IPC_CHANNELS.saveAnalysisSettings, input),
     testLocalLlmConnection: (input) =>
       ipcRenderer.invoke(IPC_CHANNELS.testLocalLlmConnection, input),
+    onAnalysisProgress: (listener) => {
+      const wrapped = (_: unknown, event: AnalysisProgressEvent) => listener(event);
+      ipcRenderer.on(IPC_CHANNELS.analysisProgress, wrapped);
+      return () => {
+        ipcRenderer.removeListener(IPC_CHANNELS.analysisProgress, wrapped);
+      };
+    },
   };
 }

--- a/apps/desktop/src/renderer/store/useAppStore.ts
+++ b/apps/desktop/src/renderer/store/useAppStore.ts
@@ -605,82 +605,87 @@ export const useAppStore = create<AppState>((set, get) => ({
       documentParagraphs: toAnalysisParagraphInput(document),
     };
 
-    try {
-      const result = await window.litelizard.runAnalysis(payload);
-      const resultMap = new Map(result.results.map((r) => [r.paragraphId, r]));
+    const rootPath = get().rootPath;
+    const staleTextMap = new Map(staleParagraphs.map((p) => [p.id, p.light.text]));
 
-      const nextDoc: LiteLizardDocument = {
-        ...pendingDoc,
-        paragraphs: pendingDoc.paragraphs.map((paragraph) => {
-          const analyzed = resultMap.get(paragraph.id);
-          if (!analyzed) {
-            return paragraph;
-          }
-
-          return {
-            ...paragraph,
-            lizard: {
-              status: 'complete',
-              emotion: analyzed.emotion,
-              theme: analyzed.theme,
-              deepMeaning: analyzed.deepMeaning,
-              confidence: analyzed.confidence,
-              model: analyzed.model,
-              requestId: result.requestId,
-              analyzedAt: analyzed.analyzedAt,
-            },
-          };
-        }),
-      };
-
-      const rootPath = get().rootPath;
+    const unsubscribe = window.litelizard.onAnalysisProgress(({ paragraphId, result }) => {
       if (rootPath && document.source?.format === 'lzl-v1') {
-        const staleTextMap = new Map(staleParagraphs.map((p) => [p.id, p.light.text]));
-        await Promise.allSettled(
-          result.results.map((analyzed) =>
-            window.litelizard.saveAnalysisResult(rootPath, document.documentId, analyzed.paragraphId, {
-              analyzedAt: analyzed.analyzedAt,
-              result: {
-                emotion: analyzed.emotion,
-                theme: analyzed.theme,
-                deepMeaning: analyzed.deepMeaning,
-                confidence: analyzed.confidence,
-                model: analyzed.model,
-                sourceText: staleTextMap.get(analyzed.paragraphId) ?? '',
-              },
-            })
-          )
-        );
+        window.litelizard.saveAnalysisResult(rootPath, document.documentId, paragraphId, {
+          analyzedAt: result.analyzedAt,
+          result: {
+            emotion: result.emotion,
+            theme: result.theme,
+            deepMeaning: result.deepMeaning,
+            confidence: result.confidence,
+            model: result.model,
+            sourceText: staleTextMap.get(paragraphId) ?? '',
+          },
+        }).catch(() => {});
       }
 
-      set({
-        document: {
-          ...nextDoc,
-          updatedAt: new Date().toISOString(),
-        },
-        dirty: true,
-        statusMessage: '全体解析が完了しました',
+      set((state) => {
+        if (!state.document) return {};
+        return {
+          document: {
+            ...state.document,
+            paragraphs: state.document.paragraphs.map((p) =>
+              p.id === paragraphId
+                ? {
+                    ...p,
+                    lizard: {
+                      status: 'complete',
+                      emotion: result.emotion,
+                      theme: result.theme,
+                      deepMeaning: result.deepMeaning,
+                      confidence: result.confidence,
+                      model: result.model,
+                      analyzedAt: result.analyzedAt,
+                    },
+                  }
+                : p
+            ),
+          },
+        };
+      });
+    });
+
+    try {
+      const result = await window.litelizard.runAnalysis(payload);
+      set((state) => {
+        if (!state.document) return {};
+        const targetIds = new Set(payload.paragraphs.map((p) => p.paragraphId));
+        return {
+          document: {
+            ...state.document,
+            paragraphs: state.document.paragraphs.map((p) =>
+              targetIds.has(p.id) && p.lizard.status === 'complete'
+                ? { ...p, lizard: { ...p.lizard, requestId: result.requestId } }
+                : p
+            ),
+            updatedAt: new Date().toISOString(),
+          },
+          dirty: true,
+          statusMessage: '全体解析が完了しました',
+        };
       });
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Analysis failed';
-      const failedDoc: LiteLizardDocument = {
-        ...pendingDoc,
-        paragraphs: pendingDoc.paragraphs.map((paragraph) =>
-          paragraph.lizard.status === 'pending'
-            ? {
-                ...paragraph,
-                lizard: {
-                  status: 'failed',
-                  error: {
-                    code: 'ANALYSIS_ABORTED',
-                    message,
-                  },
-                },
-              }
-            : paragraph
-        ),
-      };
-      set({ document: failedDoc, statusMessage: `解析に失敗しました: ${message}` });
+      set((state) => {
+        if (!state.document) return {};
+        return {
+          document: {
+            ...state.document,
+            paragraphs: state.document.paragraphs.map((p) =>
+              p.lizard.status === 'pending'
+                ? { ...p, lizard: { status: 'failed', error: { code: 'ANALYSIS_ABORTED', message } } }
+                : p
+            ),
+          },
+          statusMessage: `解析に失敗しました: ${message}`,
+        };
+      });
+    } finally {
+      unsubscribe();
     }
   },
 

--- a/apps/desktop/src/renderer/store/useAppStore.ts
+++ b/apps/desktop/src/renderer/store/useAppStore.ts
@@ -651,17 +651,37 @@ export const useAppStore = create<AppState>((set, get) => ({
 
     try {
       const result = await window.litelizard.runAnalysis(payload);
+      const resultMap = new Map(result.results.map((r) => [r.paragraphId, r]));
       set((state) => {
         if (!state.document) return {};
-        const targetIds = new Set(payload.paragraphs.map((p) => p.paragraphId));
         return {
           document: {
             ...state.document,
-            paragraphs: state.document.paragraphs.map((p) =>
-              targetIds.has(p.id) && p.lizard.status === 'complete'
-                ? { ...p, lizard: { ...p.lizard, requestId: result.requestId } }
-                : p
-            ),
+            paragraphs: state.document.paragraphs.map((p) => {
+              const analyzed = resultMap.get(p.id);
+              if (!analyzed) return p;
+              // progress で既に complete になった段落は requestId だけ付与
+              if (p.lizard.status === 'complete') {
+                return { ...p, lizard: { ...p.lizard, requestId: result.requestId } };
+              }
+              // リトライで progress が来なかった pending 段落に最終結果を適用
+              if (p.lizard.status === 'pending') {
+                return {
+                  ...p,
+                  lizard: {
+                    status: 'complete',
+                    emotion: analyzed.emotion,
+                    theme: analyzed.theme,
+                    deepMeaning: analyzed.deepMeaning,
+                    confidence: analyzed.confidence,
+                    model: analyzed.model,
+                    requestId: result.requestId,
+                    analyzedAt: analyzed.analyzedAt,
+                  },
+                };
+              }
+              return p;
+            }),
             updatedAt: new Date().toISOString(),
           },
           dirty: true,
@@ -681,6 +701,8 @@ export const useAppStore = create<AppState>((set, get) => ({
                 : p
             ),
           },
+          // progress で complete になった段落があれば保存が必要
+          dirty: true,
           statusMessage: `解析に失敗しました: ${message}`,
         };
       });

--- a/docs/wbs.md
+++ b/docs/wbs.md
@@ -1,7 +1,7 @@
 # LiteLizard WBS（Work Breakdown Structure）
 
 > **目的**: 仕様 v003 → 製品完成までの全タスクを網羅し、Codex 並列開発を可能にする
-> **最終更新**: 2026-04-21
+> **最終更新**: 2026-04-23
 > **仕様参照**: `docs/LiteLizard_spec_v003.md`
 
 ---
@@ -135,7 +135,7 @@
 | L-02 | API キー暗号化保存（main: safeStorage） | E-01 ✅ | P1 | M | ✅ | | |
 | L-03 | LLM プロバイダー抽象化層（main: provider interface） | L-02 | P1 | L | ✅ | Codex | |
 | L-04 | 外部 API 方式の解析リクエスト実装（main → OpenAI/Anthropic） | L-03 | P1 | M | ✅ | Claude | claude/next-task-F7SoK |
-| L-05 | 解析結果の IPC ストリーミング（main → renderer） | L-04, E-01 ✅ | P1 | M | ⬜ | | |
+| L-05 | 解析結果の IPC ストリーミング（main → renderer） | L-04, E-01 ✅ | P1 | M | ✅ | Claude | claude/review-task-checklist-ygfSP |
 | L-06 | 解析結果の保存・UI 反映 | L-05, E-06 ✅ | P1 | M | ⬜ | | |
 | L-07 | API キー未設定時の UI 制御（設定導線表示） | L-01 | P1 | S | ✅ | Codex | |
 | L-08 | ローカル LLM 接続（Ollama 等） | L-03 | P2 | M | ⬜ | | |
@@ -165,9 +165,9 @@
   - `useAppStore.ts` `runAnalysis`/`runAnalysisFor`: 解析成功後に `saveAnalysisResult` IPC を呼び出して結果を世代ファイルに永続化（`Promise.allSettled` で保存失敗は UI をブロックしない）
   - `packages/shared/tsconfig.json`: `types: ["node"]` を追加し `AnalysisResult` が `any` 推論されていた問題を修正
 
-#### L-05: 解析結果の IPC ストリーミング
-- **対象**: `webContents.send` で段落ごとの分析結果を renderer に逐次送信
-- **注**: SSE ではなく IPC イベントで逐次返却
+#### L-05: 解析結果の IPC ストリーミング ✅
+- **完了**: 2026-04-23。`analysis:progress` IPC チャンネルを追加し、main が段落を1件解析するたびに `event.sender.send` で renderer に逐次送信する。renderer 側は `onAnalysisProgress` リスナーで受け取り段落カードをリアルタイム更新。`saveAnalysisResult` も progress ハンドラー内で非ブロック呼び出しに変更。invoke 完了後に `requestId` を後付け付与。
+- **変更ファイル**: `packages/shared/src/bridge.ts`（型・チャンネル追加）、`apiBridge.ts`（onProgress コールバック）、`ipc.ts`（event.sender.send）、`preload/ipcBridge.ts`（リスナー実装）、`useAppStore.ts`（ストリーミング対応）
 
 ---
 
@@ -195,8 +195,8 @@
 | R-02 | Backspace での段落統合 | S-07 ✅ | P1 | M | ✅ | Claude | feat/R-02 |
 | R-03 | 構造操作の Undo/Redo | S-08 ✅ | P2 | L | ⬜ | | |
 | R-04 | エクスプローラー: .lzl 拡張子非表示 + 自動付与 | E-02 | P1 | S | ✅ | 2026-04-17 | |
-| R-05 | エクスプローラー: .litelizard/ 非表示 | E-05 ✅ | P1 | S | ⬜ | | |
-| R-06 | エクスプローラー: 削除時に解析 JSON 連動削除 | E-06 ✅ | P1 | S | ⬜ | | |
+| R-05 | エクスプローラー: .litelizard/ 非表示 | E-05 ✅ | P1 | S | ✅ | Claude | claude/review-task-checklist-ygfSP |
+| R-06 | エクスプローラー: 削除時に解析 JSON 連動削除 | E-06 ✅ | P1 | S | ✅ | | (E-06 実装時に完了済み) |
 | R-07 | 章サマリー解析表示（マクロ視点時の分析ペイン） | L-06 | P2 | M | ⛔ | | |
 | R-08 | 全体解析の成功/失敗件数表示 | L-06 | P2 | S | ⛔ | | |
 | R-09 | sourceHash による stale 検出・表示 | L-06 | P1 | S | ⛔ | | |

--- a/packages/shared/src/bridge.ts
+++ b/packages/shared/src/bridge.ts
@@ -6,7 +6,12 @@ import type {
   LiteLizardDocument,
   ParagraphAnalysisPattern,
 } from './types.js';
-import type { AnalysisRunInput, AnalysisRunResult } from './api.js';
+import type { AnalysisResult, AnalysisRunInput, AnalysisRunResult } from './api.js';
+
+export interface AnalysisProgressEvent {
+  paragraphId: string;
+  result: AnalysisResult;
+}
 
 /**
  * Renderer → Main プロセス間の API 契約。
@@ -51,6 +56,7 @@ export interface BridgeApi {
   testLocalLlmConnection(
     input: { endpoint: string; model: string }
   ): Promise<{ ok: true; model?: string } | { ok: false; message: string }>;
+  onAnalysisProgress(listener: (event: AnalysisProgressEvent) => void): () => void;
 }
 
 /**
@@ -78,6 +84,7 @@ export const IPC_CHANNELS = {
   clearProviderApiKey: 'settings:analysis:clearProviderApiKey',
   saveAnalysisSettings: 'settings:analysis:save',
   testLocalLlmConnection: 'settings:analysis:testLocalLlmConnection',
-} as const satisfies Record<Exclude<keyof BridgeApi, 'onRequestOpenFolder'> | 'requestOpenFolder', string>;
+  analysisProgress: 'analysis:progress',
+} as const satisfies Record<Exclude<keyof BridgeApi, 'onRequestOpenFolder' | 'onAnalysisProgress'> | 'requestOpenFolder' | 'analysisProgress', string>;
 
 export type IpcChannelName = (typeof IPC_CHANNELS)[keyof typeof IPC_CHANNELS];


### PR DESCRIPTION
## Summary

- **L-05**: `analysis:progress` IPC チャンネルを追加し、段落解析が完了するたびに `event.sender.send` で renderer に逐次送信。`onAnalysisProgress` リスナーで段落カードをリアルタイム更新し、`saveAnalysisResult` も progress ハンドラー内で非ブロック呼び出しに変更（invoke 完了後に `requestId` を後付け適用）
- **R-05**: `fileService.walk()` で `entry.name === '.litelizard'` をスキップし、エクスプローラーに `.litelizard/` が表示されないようにした
- **R-06**: E-06 実装時に `ipc.ts` の `deleteEntry` が `deleteAnalysisFiles()` を呼び出す形で既に完了済みだったため、WBS ステータスを ✅ に更新

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `packages/shared/src/bridge.ts` | `AnalysisProgressEvent` 型・`onAnalysisProgress` メソッド・`analysisProgress` チャンネル追加 |
| `apps/desktop/src/main/apiBridge.ts` | `onProgress` コールバック引数追加、ループ内で呼び出し |
| `apps/desktop/src/main/ipc.ts` | `event.sender.send` で progress イベントを流す |
| `apps/desktop/src/preload/ipcBridge.ts` | `onAnalysisProgress` リスナー実装 |
| `apps/desktop/src/renderer/store/useAppStore.ts` | `runAnalysis` をストリーミング対応に変更 |
| `apps/desktop/src/main/fileService.ts` | `walk()` に `.litelizard` スキップを追加 |
| `docs/wbs.md` / `CHANGELOG.md` | L-05・R-05・R-06 を ✅ に更新 |

## Test plan

- [ ] 複数段落のドキュメントで「全体解析」を実行し、段落カードが1枚ずつ `pending → complete` に更新されることを確認
- [ ] 解析エラー時に完了済み段落は `complete`、未処理段落は `failed` になることを確認
- [ ] `.litelizard/` がエクスプローラーに表示されないことを確認
- [ ] `.lzl` ファイル削除後、`.litelizard/analysis/` に対応する世代 JSON が残らないことを確認
- [ ] `pnpm exec tsc --noEmit` でエラーなし

https://claude.ai/code/session_01QW2KgtYteFEe1a1Xf1UgYr

---
_Generated by [Claude Code](https://claude.ai/code/session_01QW2KgtYteFEe1a1Xf1UgYr)_