### PR TITLE
feat(R-14): 既存テキストインポート機能を追加

### DIFF
--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -2,10 +2,12 @@ import path from 'node:path';
 import fs from 'node:fs/promises';
 import { app, dialog, ipcMain } from 'electron';
 import {
+  buildImportedDocument,
   createChapterId,
   createDocumentId,
   createParagraphId,
   IPC_CHANNELS,
+  parseTextToImportResult,
   type AnalysisRunInput,
   type AnalysisSettingsInput,
   type LiteLizardDocument,
@@ -427,6 +429,39 @@ export function registerIpcHandlers() {
     } catch (error) {
       console.error('[IPC analysis:newGeneration] failed', error);
       throw new Error(`CREATE_GENERATION_FAILED: ${getErrorMessage(error)}`);
+    }
+  });
+
+  ipcMain.handle(IPC_CHANNELS.importTextFile, async (_, createParent: string) => {
+    try {
+      const result = await dialog.showOpenDialog({
+        properties: ['openFile'],
+        filters: [{ name: 'Text Files', extensions: ['txt', 'md'] }],
+      });
+
+      if (result.canceled || result.filePaths.length === 0) {
+        return null;
+      }
+
+      const sourceFilePath = result.filePaths[0];
+      const rawText = await fs.readFile(sourceFilePath, 'utf8');
+      const title = toTitleFromFileName(path.basename(sourceFilePath));
+      const importResult = parseTextToImportResult(rawText, title);
+
+      const destFileName = ensureLzlFileName(sanitizeFileStem(title));
+      const destFilePath = path.join(createParent, destFileName);
+
+      if (await fileExists(destFilePath)) {
+        throw new Error(`IMPORT_FILE_ALREADY_EXISTS: ${destFileName}`);
+      }
+
+      const document = buildImportedDocument(importResult, destFilePath);
+      await fileService.createDocument(destFilePath, document);
+
+      return { ok: true as const, filePath: destFilePath, document };
+    } catch (error) {
+      console.error('[IPC doc:importText] failed', error);
+      throw new Error(`IMPORT_TEXT_FAILED: ${getErrorMessage(error)}`);
     }
   });
 }

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -445,7 +445,8 @@ export function registerIpcHandlers() {
 
       const sourceFilePath = result.filePaths[0];
       const rawText = await fs.readFile(sourceFilePath, 'utf8');
-      const title = toTitleFromFileName(path.basename(sourceFilePath));
+      const baseName = path.basename(sourceFilePath);
+      const title = baseName.replace(/\.[^.]+$/, '') || baseName;
       const importResult = parseTextToImportResult(rawText, title);
 
       const destFileName = ensureLzlFileName(sanitizeFileStem(title));

--- a/apps/desktop/src/preload/ipcBridge.ts
+++ b/apps/desktop/src/preload/ipcBridge.ts
@@ -47,5 +47,7 @@ export function createIpcBridge(): BridgeApi {
       ipcRenderer.invoke(IPC_CHANNELS.saveAnalysisSettings, input),
     testLocalLlmConnection: (input) =>
       ipcRenderer.invoke(IPC_CHANNELS.testLocalLlmConnection, input),
+    importTextFile: (createParent) =>
+      ipcRenderer.invoke(IPC_CHANNELS.importTextFile, createParent),
   };
 }

--- a/apps/desktop/src/preload/preloadMockApi.ts
+++ b/apps/desktop/src/preload/preloadMockApi.ts
@@ -1,5 +1,7 @@
 import {
+  buildImportedDocument,
   DEFAULT_ANALYSIS_SETTINGS,
+  parseTextToImportResult,
   type AnalysisRunInput,
   type AnalysisRunResult,
   type AnalysisSettings,
@@ -508,6 +510,25 @@ export function createMockPreloadApi(): BridgeApi {
 
     createAnalysisGeneration: async (_projectRoot: string, _documentId: string) => {
       return 1;
+    },
+
+    importTextFile: async (createParent: string) => {
+      const sampleText = `# サンプル章\n\nサンプル段落1。\n\nサンプル段落2。`;
+      const fileName = withLzlExtension('imported-sample');
+      const filePath = joinPath(createParent, fileName);
+
+      if (pathExists(state.tree, filePath)) {
+        throw new Error(`IMPORT_FILE_ALREADY_EXISTS: ${filePath}`);
+      }
+
+      const importResult = parseTextToImportResult(sampleText, 'imported-sample');
+      const document = buildImportedDocument(importResult, filePath);
+      const children = findDirectoryChildren(state, createParent);
+      children.push({ path: filePath, name: fileName, type: 'file' });
+      state.documents.set(normalizePath(filePath), document);
+      state.revisions.set(normalizePath(filePath), 0);
+
+      return { ok: true as const, filePath, document: clone(document) };
     },
   };
 }

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -40,6 +40,7 @@ function WorkspaceShell() {
     createEntry,
     renameEntry,
     deleteEntry,
+    importTextFile,
     loadDocument,
     reorderParagraphs,
     reorderChapters,
@@ -190,6 +191,7 @@ function WorkspaceShell() {
               onRenameEntry={(targetPath, nextName) => void renameEntry(targetPath, nextName)}
               onDeleteEntry={(targetPath) => void deleteEntry(targetPath)}
               onSelectFile={(path) => void loadDocument(path)}
+              onImportTextFile={(createParent) => void importTextFile(createParent)}
             />
           )}
           {explorerOpen && !isCompactLayout && (

--- a/apps/desktop/src/renderer/components/ExplorerPane.tsx
+++ b/apps/desktop/src/renderer/components/ExplorerPane.tsx
@@ -10,6 +10,7 @@ interface Props {
   onRenameEntry: (targetPath: string, nextName: string) => void;
   onDeleteEntry: (targetPath: string) => void;
   onSelectFile: (path: string) => void;
+  onImportTextFile: (createParent: string) => void;
 }
 
 interface InlineCreateState {
@@ -68,6 +69,29 @@ function FileIcon() {
     <svg viewBox="0 0 24 24" width={16} height={16} aria-hidden>
       <path
         d="M7 3.5h7l4.5 4.5v11a1.5 1.5 0 0 1-1.5 1.5h-10A1.5 1.5 0 0 1 5.5 19V5A1.5 1.5 0 0 1 7 3.5Zm6 1.8V9h3.7"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function ImportIcon() {
+  return (
+    <svg viewBox="0 0 24 24" width={16} height={16} aria-hidden>
+      <path
+        d="M7 3.5h7l4.5 4.5v11a1.5 1.5 0 0 1-1.5 1.5h-10A1.5 1.5 0 0 1 5.5 19V5A1.5 1.5 0 0 1 7 3.5Zm6 1.8V9h3.7"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M12 12v5m-2-2 2 2 2-2"
         fill="none"
         stroke="currentColor"
         strokeWidth="1.6"
@@ -291,6 +315,7 @@ export function ExplorerPane({
   onRenameEntry,
   onDeleteEntry,
   onSelectFile,
+  onImportTextFile,
 }: Props) {
   const [expanded, setExpanded] = useState<Set<string> | null>(null);
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
@@ -430,6 +455,15 @@ export function ExplorerPane({
             >
               <span className="explorer-icon-wrap"><FolderIcon /><span className="explorer-add-plus">+</span></span>
             </button>
+            <button
+              className="icon-button explorer-add-btn"
+              onClick={() => onImportTextFile(createParent)}
+              disabled={!canCreate}
+              title="テキストをインポート"
+              aria-label="テキストをインポート"
+            >
+              <ImportIcon />
+            </button>
           </div>
         </div>
 
@@ -491,6 +525,16 @@ export function ExplorerPane({
             }}
           >
             新規フォルダ
+          </button>
+          <button
+            className="menu-item"
+            onClick={() => {
+              const parentPath = resolveCreateParent(contextMenu);
+              onImportTextFile(parentPath);
+              setContextMenu(null);
+            }}
+          >
+            テキストをインポート
           </button>
           <button
             className="menu-item"

--- a/apps/desktop/src/renderer/store/useAppStore.ts
+++ b/apps/desktop/src/renderer/store/useAppStore.ts
@@ -129,6 +129,7 @@ interface AppState {
   createEntry: (parentPath: string, type: 'file' | 'folder', name: string) => Promise<void>;
   renameEntry: (targetPath: string, nextName: string) => Promise<void>;
   deleteEntry: (targetPath: string) => Promise<void>;
+  importTextFile: (createParent: string) => Promise<void>;
   loadDocument: (filePath: string) => Promise<void>;
   updateParagraph: (paragraphId: string, text: string) => void;
   reorderParagraphs: (orderedIds: string[]) => void;
@@ -429,6 +430,35 @@ export const useAppStore = create<AppState>((set, get) => ({
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error';
       set({ statusMessage: `削除に失敗しました: ${message}` });
+    }
+  },
+
+  importTextFile: async (createParent: string) => {
+    try {
+      const result = await window.litelizard.importTextFile(createParent);
+      if (!result) return;
+
+      const rootPath = get().rootPath;
+      if (rootPath) {
+        const tree = await window.litelizard.listTree(rootPath);
+        set({ tree });
+      }
+
+      const document = await window.litelizard.loadDocument(result.filePath);
+      set({
+        currentFilePath: result.filePath,
+        document,
+        revision: 0,
+        dirty: false,
+        statusMessage: 'テキストをインポートしました',
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      if (message.includes('IMPORT_FILE_ALREADY_EXISTS')) {
+        set({ statusMessage: '同名の .lzl ファイルが既に存在します' });
+        return;
+      }
+      set({ statusMessage: `インポートに失敗しました: ${message}` });
     }
   },
 

--- a/packages/shared/src/bridge.ts
+++ b/packages/shared/src/bridge.ts
@@ -51,6 +51,9 @@ export interface BridgeApi {
   testLocalLlmConnection(
     input: { endpoint: string; model: string }
   ): Promise<{ ok: true; model?: string } | { ok: false; message: string }>;
+  importTextFile(
+    createParent: string,
+  ): Promise<{ ok: true; filePath: string; document: LiteLizardDocument } | null>;
 }
 
 /**
@@ -78,6 +81,7 @@ export const IPC_CHANNELS = {
   clearProviderApiKey: 'settings:analysis:clearProviderApiKey',
   saveAnalysisSettings: 'settings:analysis:save',
   testLocalLlmConnection: 'settings:analysis:testLocalLlmConnection',
+  importTextFile: 'doc:importText',
 } as const satisfies Record<Exclude<keyof BridgeApi, 'onRequestOpenFolder'> | 'requestOpenFolder', string>;
 
 export type IpcChannelName = (typeof IPC_CHANNELS)[keyof typeof IPC_CHANNELS];

--- a/packages/shared/src/lzl/index.ts
+++ b/packages/shared/src/lzl/index.ts
@@ -4,3 +4,4 @@ export * from './parser.js';
 export * from './serializer.js';
 export * from './validator.js';
 export * from './converter.js';
+export * from './textImporter.js';

--- a/packages/shared/src/lzl/textImporter.ts
+++ b/packages/shared/src/lzl/textImporter.ts
@@ -1,0 +1,141 @@
+import { createChapterId, createDocumentId, createParagraphId } from './ids.js';
+import type { LiteLizardDocument } from '../types.js';
+
+const HEADING_PATTERN = /^#{1,6}\s+(.+)$/;
+
+export interface TextImportChapter {
+  title: string;
+  paragraphs: string[];
+}
+
+export interface TextImportResult {
+  title: string;
+  chapters: TextImportChapter[];
+}
+
+export function parseTextToImportResult(text: string, fileTitle: string): TextImportResult {
+  const lines = text.replace(/\r\n/g, '\n').split('\n');
+
+  const chapters: TextImportChapter[] = [];
+  let currentChapterTitle: string | null = null;
+  let currentParagraphs: string[] = [];
+  let buffer: string[] = [];
+
+  const flushParagraph = () => {
+    const paragraph = buffer.join('\n').trim();
+    buffer = [];
+    if (paragraph.length === 0) return;
+    currentParagraphs.push(paragraph);
+  };
+
+  const flushChapter = () => {
+    flushParagraph();
+    if (currentChapterTitle !== null) {
+      chapters.push({ title: currentChapterTitle, paragraphs: currentParagraphs });
+    } else if (currentParagraphs.length > 0) {
+      // 見出し登場前の段落を保留リストに退避（後で先頭章に付ける）
+      chapters.push({ title: fileTitle, paragraphs: currentParagraphs });
+    }
+    currentParagraphs = [];
+    currentChapterTitle = null;
+  };
+
+  for (const line of lines) {
+    const headingMatch = line.match(HEADING_PATTERN);
+    if (headingMatch) {
+      flushChapter();
+      currentChapterTitle = headingMatch[1].trim();
+      continue;
+    }
+
+    if (line.trim() === '') {
+      flushParagraph();
+      continue;
+    }
+
+    buffer.push(line);
+  }
+
+  // 最後の章をフラッシュ
+  if (currentChapterTitle !== null) {
+    flushParagraph();
+    chapters.push({ title: currentChapterTitle, paragraphs: currentParagraphs });
+  } else {
+    // 見出しが一度もなかった場合
+    flushParagraph();
+    if (currentParagraphs.length > 0) {
+      if (chapters.length === 0) {
+        chapters.push({ title: fileTitle, paragraphs: currentParagraphs });
+      } else {
+        // 見出し登場前のフリー段落を最初の章の先頭に挿入（通常は発生しない）
+        chapters[0] = {
+          ...chapters[0],
+          paragraphs: [...currentParagraphs, ...chapters[0].paragraphs],
+        };
+      }
+    }
+  }
+
+  // 章が0個 → fileTitle の単一章を生成
+  if (chapters.length === 0) {
+    chapters.push({ title: fileTitle, paragraphs: [] });
+  }
+
+  return { title: fileTitle, chapters };
+}
+
+export function buildImportedDocument(
+  result: TextImportResult,
+  filePath: string,
+): LiteLizardDocument {
+  const now = new Date().toISOString();
+  const documentId = createDocumentId();
+
+  const lzlChapters: LiteLizardDocument['chapters'] = [];
+  const lzlParagraphs: LiteLizardDocument['paragraphs'] = [];
+
+  for (let chapterIndex = 0; chapterIndex < result.chapters.length; chapterIndex++) {
+    const importChapter = result.chapters[chapterIndex];
+    const chapterId = createChapterId();
+
+    lzlChapters.push({
+      id: chapterId,
+      order: chapterIndex + 1,
+      title: importChapter.title,
+    });
+
+    const paragraphTexts =
+      importChapter.paragraphs.length > 0 ? importChapter.paragraphs : [''];
+
+    for (let paragraphIndex = 0; paragraphIndex < paragraphTexts.length; paragraphIndex++) {
+      const text = paragraphTexts[paragraphIndex];
+      lzlParagraphs.push({
+        id: createParagraphId(),
+        chapterId,
+        order: paragraphIndex + 1,
+        light: {
+          text,
+          charCount: text.length,
+        },
+        lizard: {
+          status: 'stale',
+        },
+      });
+    }
+  }
+
+  return {
+    version: 2,
+    documentId,
+    title: result.title,
+    personaMode: 'general-reader',
+    createdAt: now,
+    updatedAt: now,
+    source: {
+      format: 'lzl-v1',
+      originPath: filePath,
+    },
+    chapters: lzlChapters,
+    paragraphs: lzlParagraphs,
+  };
+}


### PR DESCRIPTION
## Summary

- `.txt` / `.md` ファイルを選択して `.lzl` に変換・保存するインポート機能を実装（WBS R-14）
- Markdown見出し（`#`〜`######`）を章区切りとして解釈し、見出しテキストが章タイトルになる
- 空行区切りで段落を分割。空段落は除外。章・段落IDは `createChapterId()` / `createParagraphId()` で自動生成
- エクスプローラーのツールバーとコンテキストメニューの両方からトリガー可能

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `packages/shared/src/lzl/textImporter.ts`（新規） | `parseTextToImportResult` + `buildImportedDocument` の変換ロジック |
| `packages/shared/src/bridge.ts` | `BridgeApi.importTextFile` と `IPC_CHANNELS.importTextFile` を追加 |
| `apps/desktop/src/main/ipc.ts` | `doc:importText` IPC ハンドラ（ダイアログ・読込・変換・保存） |
| `apps/desktop/src/preload/ipcBridge.ts` | `importTextFile` ブリッジを追加 |
| `apps/desktop/src/preload/preloadMockApi.ts` | モック実装を追加 |
| `apps/desktop/src/renderer/store/useAppStore.ts` | `importTextFile` アクションを追加 |
| `apps/desktop/src/renderer/components/ExplorerPane.tsx` | ツールバーボタン・コンテキストメニュー項目を追加 |
| `apps/desktop/src/renderer/App.tsx` | `onImportTextFile` prop を接続 |

## Test plan

- [ ] エクスプローラーのツールバーにインポートボタンが表示される
- [ ] コンテキストメニューに「テキストをインポート」が表示される
- [ ] `.txt` ファイルを選択すると `.lzl` が生成されてエディタで開かれる
- [ ] `.md` ファイルを選択すると Markdown 見出しが章として解釈される
- [ ] 同名の `.lzl` が既存の場合にエラーメッセージが表示される
- [ ] ダイアログをキャンセルしても何も起きない
- [ ] 全テスト通過: `pnpm --filter @litelizard/shared test`

https://claude.ai/code/session_01HtKGVpZxuvxBnV97Qm94KX

---
_Generated by [Claude Code](https://claude.ai/code/session_01HtKGVpZxuvxBnV97Qm94KX)_