### PR TITLE
feat(R-03): 構造操作の Undo/Redo を実装

### DIFF
--- a/apps/desktop/src/renderer/components/editor/MicroEditorView.tsx
+++ b/apps/desktop/src/renderer/components/editor/MicroEditorView.tsx
@@ -10,7 +10,7 @@ import {
 import { LexicalComposer } from '@lexical/react/LexicalComposer';
 import { RichTextPlugin } from '@lexical/react/LexicalRichTextPlugin';
 import { ContentEditable } from '@lexical/react/LexicalContentEditable';
-import { HistoryPlugin } from '@lexical/react/LexicalHistoryPlugin';
+import { UndoPlugin } from './plugins/UndoPlugin.js';
 import { LexicalErrorBoundary, type LexicalErrorBoundaryProps } from '@lexical/react/LexicalErrorBoundary';
 import { DndContext, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
@@ -29,6 +29,7 @@ import {
   type StructureSnapshot,
 } from './utils/structureBuilder.js';
 import { mergeChapterIdByNodeKey, mergeParagraphIdByNodeKey } from './utils/nodeKeyMapping.js';
+import { useAppStore } from '../../store/useAppStore.js';
 
 const RichTextErrorBoundary: React.ComponentType<LexicalErrorBoundaryProps> = LexicalErrorBoundary;
 
@@ -82,6 +83,7 @@ export function MicroEditorView({
     chapterNodeKeySetRef.current = new Set();
     consumedScrollRequestNonceRef.current = null;
     initialBaselineCapturedRef.current = false;
+    useAppStore.getState().clearUndoStacks();
   }, [document.documentId]);
 
   // nodeKey ↔ ID マッピングの同期
@@ -331,7 +333,7 @@ export function MicroEditorView({
               containerRef={containerRef}
             />
 
-            <HistoryPlugin />
+            <UndoPlugin chapterNodeKeySetRef={chapterNodeKeySetRef} />
 
             <RichTextPlugin
               contentEditable={<ContentEditable className="editor-paragraph-textarea" />}

--- a/apps/desktop/src/renderer/components/editor/plugins/ChapterCommandPlugin.tsx
+++ b/apps/desktop/src/renderer/components/editor/plugins/ChapterCommandPlugin.tsx
@@ -7,6 +7,7 @@ import {
   KEY_TAB_COMMAND,
   $createParagraphNode,
   $createTextNode,
+  $getRoot,
   $getSelection,
   $isParagraphNode,
   $isRangeSelection,
@@ -14,6 +15,7 @@ import {
   type ParagraphNode,
 } from 'lexical';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import { useAppStore } from '../../../store/useAppStore.js';
 
 /** 指定ノードより前に章ノードが存在するか（先頭章判定に使用）*/
 function hasPrecedingChapterNode(node: LexicalNode, chapterNodeKeySet: Set<string>): boolean {
@@ -102,6 +104,14 @@ export function ChapterCommandPlugin({
 
         if (hasModifier) {
           event.preventDefault();
+          const store = useAppStore.getState();
+          const doc = store.document;
+          if (doc) {
+            store.pushUndo({
+              lexicalStateJson: JSON.stringify(editor.getEditorState().toJSON()),
+              documentSnapshot: doc,
+            });
+          }
           editor.update(() => {
             const selection = $getSelection();
             if (!$isRangeSelection(selection)) {
@@ -135,8 +145,26 @@ export function ChapterCommandPlugin({
             chapterParagraph.insertAfter(bodyParagraph);
             chapterNodeKeySetRef.current.add(chapterParagraph.getKey());
             chapterParagraph.selectStart();
-          });
+          }, { tag: 'structural' });
           return true;
+        }
+
+        // 章ノード上の Enter かを事前確認（コマンドハンドラは implicit update 内で動作するため $getSelection() 使用可）
+        const preCheckSel = $getSelection();
+        const isOnChapterNode = $isRangeSelection(preCheckSel) && (() => {
+          const tl = preCheckSel.anchor.getNode().getTopLevelElement();
+          return Boolean(tl && $isParagraphNode(tl) && chapterNodeKeySetRef.current.has(tl.getKey()));
+        })();
+
+        if (isOnChapterNode) {
+          const store = useAppStore.getState();
+          const doc = store.document;
+          if (doc) {
+            store.pushUndo({
+              lexicalStateJson: JSON.stringify(editor.getEditorState().toJSON()),
+              documentSnapshot: doc,
+            });
+          }
         }
 
         let handled = false;
@@ -167,7 +195,7 @@ export function ChapterCommandPlugin({
           const paragraph = $createParagraphNode();
           topLevel.insertAfter(paragraph);
           paragraph.selectStart();
-        });
+        }, isOnChapterNode ? { tag: 'structural' } : undefined);
 
         return handled;
       },
@@ -206,7 +234,18 @@ export function ChapterCommandPlugin({
           }
           // 非先頭章タイトル → 格下げ
           event?.preventDefault();
-          chapterNodeKeySetRef.current.delete(topLevel.getKey());
+          const demoteStore = useAppStore.getState();
+          const demoteDoc = demoteStore.document;
+          if (demoteDoc) {
+            demoteStore.pushUndo({
+              lexicalStateJson: JSON.stringify(editor.getEditorState().toJSON()),
+              documentSnapshot: demoteDoc,
+            });
+          }
+          const demoteKey = topLevel.getKey();
+          editor.update(() => {
+            chapterNodeKeySetRef.current.delete(demoteKey);
+          }, { tag: 'structural' });
           return true;
         }
 
@@ -221,21 +260,35 @@ export function ChapterCommandPlugin({
 
         // 同一章内の2番目以降の段落 → 段落統合
         event?.preventDefault();
+        const mergeStore = useAppStore.getState();
+        const mergeDoc = mergeStore.document;
+        if (mergeDoc) {
+          mergeStore.pushUndo({
+            lexicalStateJson: JSON.stringify(editor.getEditorState().toJSON()),
+            documentSnapshot: mergeDoc,
+          });
+        }
+        const prevSiblingKey = prevSibling.getKey();
+        const topLevelKey = topLevel.getKey();
         const prevText = prevSibling.getTextContent();
         const currText = topLevel.getTextContent();
-        const mergeOffset = prevText.length;
-        const mergedText = prevText + currText;
-
-        prevSibling.clear();
-        topLevel.remove();
-
-        if (mergedText.length > 0) {
-          const mergedTextNode = $createTextNode(mergedText);
-          prevSibling.append(mergedTextNode);
-          mergedTextNode.select(mergeOffset, mergeOffset);
-        } else {
-          prevSibling.selectEnd();
-        }
+        editor.update(() => {
+          const allNodes = $getRoot().getChildren().filter((n): n is ParagraphNode => $isParagraphNode(n));
+          const prevNode = allNodes.find((n) => n.getKey() === prevSiblingKey);
+          const currNode = allNodes.find((n) => n.getKey() === topLevelKey);
+          if (!prevNode || !currNode) return;
+          const mergeOffset = prevText.length;
+          const mergedText = prevText + currText;
+          prevNode.clear();
+          currNode.remove();
+          if (mergedText.length > 0) {
+            const mergedTextNode = $createTextNode(mergedText);
+            prevNode.append(mergedTextNode);
+            mergedTextNode.select(mergeOffset, mergeOffset);
+          } else {
+            prevNode.selectEnd();
+          }
+        }, { tag: 'structural' });
 
         return true;
       },

--- a/apps/desktop/src/renderer/components/editor/plugins/ChapterDeletePlugin.tsx
+++ b/apps/desktop/src/renderer/components/editor/plugins/ChapterDeletePlugin.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import { $getRoot, $isParagraphNode, type ParagraphNode } from 'lexical';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import { deleteChapterNodeInLexical } from './ChapterCommandPlugin.js';
+import { useAppStore } from '../../../store/useAppStore.js';
 
 interface Position {
   top: number;
@@ -98,6 +99,14 @@ export function ChapterDeletePlugin({ chapterNodeKeys, chapterNodeKeySetRef, con
   }, [editor, chapterNodeKeys, containerRef]);
 
   function handleDelete(nodeKey: string) {
+    const store = useAppStore.getState();
+    const doc = store.document;
+    if (doc) {
+      store.pushUndo({
+        lexicalStateJson: JSON.stringify(editor.getEditorState().toJSON()),
+        documentSnapshot: doc,
+      });
+    }
     editor.update(() => {
       const children = $getRoot().getChildren();
       const node = children.find(
@@ -106,7 +115,7 @@ export function ChapterDeletePlugin({ chapterNodeKeys, chapterNodeKeySetRef, con
       if (node) {
         deleteChapterNodeInLexical(node, chapterNodeKeySetRef);
       }
-    });
+    }, { tag: 'structural' });
   }
 
   const container = containerRef.current;

--- a/apps/desktop/src/renderer/components/editor/plugins/StructureStatePlugin.tsx
+++ b/apps/desktop/src/renderer/components/editor/plugins/StructureStatePlugin.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { $getRoot, $getSelection, $isParagraphNode, $isRangeSelection, type ParagraphNode } from 'lexical';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import type { StructureSnapshot } from '../utils/structureBuilder.js';
@@ -15,9 +15,20 @@ export function StructureStatePlugin({
   onActiveElement: (active: { nodeKey: string | null; type: 'chapter' | 'paragraph' | null }) => void;
 }) {
   const [editor] = useLexicalComposerContext();
+  const skipNextRef = useRef(false);
 
   useEffect(() => {
-    return editor.registerUpdateListener(({ editorState }) => {
+    return editor.registerUpdateListener(({ editorState, tags }) => {
+      // undo/redo 復元直後は store の document が既に復元済みのため同期をスキップ
+      if (tags.has('undo') || tags.has('redo')) {
+        skipNextRef.current = true;
+        return;
+      }
+      // undo/redo 直後の最初のタグなし更新もスキップ（nodeKey 再構築で同期が走るのを防ぐ）
+      if (skipNextRef.current) {
+        skipNextRef.current = false;
+        return;
+      }
       editorState.read(() => {
         const root = $getRoot();
         const topLevelParagraphs = root.getChildren().filter((node): node is ParagraphNode => $isParagraphNode(node));

--- a/apps/desktop/src/renderer/components/editor/plugins/UndoPlugin.tsx
+++ b/apps/desktop/src/renderer/components/editor/plugins/UndoPlugin.tsx
@@ -1,0 +1,141 @@
+import React, { useEffect, useRef } from 'react';
+import { REDO_COMMAND, UNDO_COMMAND, COMMAND_PRIORITY_CRITICAL } from 'lexical';
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import { useAppStore } from '../../../store/useAppStore.js';
+import type { UndoSnapshot } from '../../../store/useAppStore.js';
+
+const TEXT_DEBOUNCE_MS = 500;
+
+export function UndoPlugin({
+  chapterNodeKeySetRef,
+}: {
+  chapterNodeKeySetRef: React.MutableRefObject<Set<string>>;
+}) {
+  const [editor] = useLexicalComposerContext();
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingSnapshotRef = useRef<UndoSnapshot | null>(null);
+
+  useEffect(() => {
+    // テキスト編集のスナップショットキャプチャ (500ms debounce)
+    // structural/undo/redo タグが付いた更新はスキップして debounce をクリアする
+    const unregisterUpdate = editor.registerUpdateListener(({ editorState, tags }) => {
+      if (tags.has('undo') || tags.has('redo') || tags.has('structural')) {
+        if (debounceTimerRef.current !== null) {
+          clearTimeout(debounceTimerRef.current);
+          debounceTimerRef.current = null;
+        }
+        pendingSnapshotRef.current = null;
+        return;
+      }
+
+      // 最初の更新のみスナップショット確保（タイピング開始直前の状態を保存）
+      if (pendingSnapshotRef.current === null) {
+        const doc = useAppStore.getState().document;
+        if (doc) {
+          pendingSnapshotRef.current = {
+            lexicalStateJson: JSON.stringify(editorState.toJSON()),
+            documentSnapshot: doc,
+          };
+        }
+      }
+
+      if (debounceTimerRef.current !== null) {
+        clearTimeout(debounceTimerRef.current);
+      }
+
+      debounceTimerRef.current = setTimeout(() => {
+        debounceTimerRef.current = null;
+        if (pendingSnapshotRef.current) {
+          useAppStore.getState().pushUndo(pendingSnapshotRef.current);
+          pendingSnapshotRef.current = null;
+        }
+      }, TEXT_DEBOUNCE_MS);
+    });
+
+    // Ctrl+Z / Ctrl+Y のグローバルキーハンドラ
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const mod = e.metaKey || e.ctrlKey;
+      if (!mod) return;
+      const key = e.key.toLowerCase();
+      if (key === 'z' && !e.shiftKey) {
+        e.preventDefault();
+        editor.dispatchCommand(UNDO_COMMAND, undefined);
+      } else if (key === 'y' || (key === 'z' && e.shiftKey)) {
+        e.preventDefault();
+        editor.dispatchCommand(REDO_COMMAND, undefined);
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+
+    const unregisterUndo = editor.registerCommand(
+      UNDO_COMMAND,
+      () => {
+        const store = useAppStore.getState();
+        if (store.undoStack.length === 0) return true;
+        const doc = store.document;
+        if (!doc) return true;
+
+        const current: UndoSnapshot = {
+          lexicalStateJson: JSON.stringify(editor.getEditorState().toJSON()),
+          documentSnapshot: doc,
+        };
+        const target = store.undoWithCurrentSnapshot(current);
+        if (!target) return true;
+
+        if (debounceTimerRef.current !== null) {
+          clearTimeout(debounceTimerRef.current);
+          debounceTimerRef.current = null;
+        }
+        pendingSnapshotRef.current = null;
+
+        // undo/redo 復元時の StructureStatePlugin による上書きを防ぐため 'undo' タグを付与
+        chapterNodeKeySetRef.current.clear();
+        editor.setEditorState(editor.parseEditorState(target.lexicalStateJson), { tag: 'undo' });
+        store.restoreSnapshot(target);
+        return true;
+      },
+      COMMAND_PRIORITY_CRITICAL,
+    );
+
+    const unregisterRedo = editor.registerCommand(
+      REDO_COMMAND,
+      () => {
+        const store = useAppStore.getState();
+        if (store.redoStack.length === 0) return true;
+        const doc = store.document;
+        if (!doc) return true;
+
+        const current: UndoSnapshot = {
+          lexicalStateJson: JSON.stringify(editor.getEditorState().toJSON()),
+          documentSnapshot: doc,
+        };
+        const target = store.redoWithCurrentSnapshot(current);
+        if (!target) return true;
+
+        if (debounceTimerRef.current !== null) {
+          clearTimeout(debounceTimerRef.current);
+          debounceTimerRef.current = null;
+        }
+        pendingSnapshotRef.current = null;
+
+        chapterNodeKeySetRef.current.clear();
+        editor.setEditorState(editor.parseEditorState(target.lexicalStateJson), { tag: 'redo' });
+        store.restoreSnapshot(target);
+        return true;
+      },
+      COMMAND_PRIORITY_CRITICAL,
+    );
+
+    return () => {
+      unregisterUpdate();
+      unregisterUndo();
+      unregisterRedo();
+      window.removeEventListener('keydown', handleKeyDown);
+      if (debounceTimerRef.current !== null) {
+        clearTimeout(debounceTimerRef.current);
+      }
+    };
+  }, [editor, chapterNodeKeySetRef]);
+
+  return null;
+}

--- a/apps/desktop/src/renderer/components/editor/plugins/UndoPlugin.tsx
+++ b/apps/desktop/src/renderer/components/editor/plugins/UndoPlugin.tsx
@@ -18,7 +18,7 @@ export function UndoPlugin({
   useEffect(() => {
     // テキスト編集のスナップショットキャプチャ (500ms debounce)
     // structural/undo/redo タグが付いた更新はスキップして debounce をクリアする
-    const unregisterUpdate = editor.registerUpdateListener(({ editorState, tags }) => {
+    const unregisterUpdate = editor.registerUpdateListener(({ prevEditorState, tags }) => {
       if (tags.has('undo') || tags.has('redo') || tags.has('structural')) {
         if (debounceTimerRef.current !== null) {
           clearTimeout(debounceTimerRef.current);
@@ -28,14 +28,19 @@ export function UndoPlugin({
         return;
       }
 
-      // 最初の更新のみスナップショット確保（タイピング開始直前の状態を保存）
+      const store = useAppStore.getState();
+
+      // 最初の更新のみ「変更直前」状態をスナップショット確保
+      // prevEditorState = この更新が適用される前の状態 = Undo で戻るべき状態
       if (pendingSnapshotRef.current === null) {
-        const doc = useAppStore.getState().document;
+        const doc = store.document;
         if (doc) {
           pendingSnapshotRef.current = {
-            lexicalStateJson: JSON.stringify(editorState.toJSON()),
+            lexicalStateJson: JSON.stringify(prevEditorState.toJSON()),
             documentSnapshot: doc,
           };
+          // 編集開始時点で Redo 履歴を即時クリア（500ms 待ちだと Ctrl+Y で古い Redo が実行される）
+          store.clearRedoStack();
         }
       }
 
@@ -53,9 +58,12 @@ export function UndoPlugin({
     });
 
     // Ctrl+Z / Ctrl+Y のグローバルキーハンドラ
+    // エディタのルート要素にフォーカスがある場合のみ処理する（入力欄での誤作動を防ぐ）
     const handleKeyDown = (e: KeyboardEvent) => {
       const mod = e.metaKey || e.ctrlKey;
       if (!mod) return;
+      const rootElement = editor.getRootElement();
+      if (!rootElement || !rootElement.contains(document.activeElement)) return;
       const key = e.key.toLowerCase();
       if (key === 'z' && !e.shiftKey) {
         e.preventDefault();

--- a/apps/desktop/src/renderer/store/useAppStore.ts
+++ b/apps/desktop/src/renderer/store/useAppStore.ts
@@ -114,6 +114,7 @@ interface AppState {
   redoWithCurrentSnapshot: (current: UndoSnapshot) => UndoSnapshot | null;
   restoreSnapshot: (snapshot: UndoSnapshot) => void;
   clearUndoStacks: () => void;
+  clearRedoStack: () => void;
   hydrateProject: (rootPath: string, source: 'restore' | 'dialog') => Promise<void>;
   restoreLastProject: () => Promise<void>;
   openFolder: () => Promise<void>;
@@ -488,6 +489,10 @@ export const useAppStore = create<AppState>((set, get) => {
 
   clearUndoStacks: () => {
     set({ undoStack: [], redoStack: [] });
+  },
+
+  clearRedoStack: () => {
+    set({ redoStack: [] });
   },
 
   hydrateProject: async (rootPath, source) => {

--- a/apps/desktop/src/renderer/store/useAppStore.ts
+++ b/apps/desktop/src/renderer/store/useAppStore.ts
@@ -31,6 +31,11 @@ export type ViewScale = 'micro' | 'macro';
 export type StartupState = 'loading' | 'needs-project' | 'ready';
 export type WorkspacePanel = 'editor' | 'settings';
 
+export interface UndoSnapshot {
+  lexicalStateJson: string;
+  documentSnapshot: LiteLizardDocument;
+}
+
 function getSelectedAnalysisProviderState(settings: AnalysisSettings) {
   if (settings.defaultProvider === 'openai') {
     return {
@@ -102,6 +107,13 @@ interface AppState {
   viewScale: ViewScale;
   analysisLayerOpen: boolean;
   statusMessage: string;
+  undoStack: UndoSnapshot[];
+  redoStack: UndoSnapshot[];
+  pushUndo: (snapshot: UndoSnapshot) => void;
+  undoWithCurrentSnapshot: (current: UndoSnapshot) => UndoSnapshot | null;
+  redoWithCurrentSnapshot: (current: UndoSnapshot) => UndoSnapshot | null;
+  restoreSnapshot: (snapshot: UndoSnapshot) => void;
+  clearUndoStacks: () => void;
   hydrateProject: (rootPath: string, source: 'restore' | 'dialog') => Promise<void>;
   restoreLastProject: () => Promise<void>;
   openFolder: () => Promise<void>;
@@ -259,6 +271,11 @@ export const useAppStore = create<AppState>((set, get) => {
     generationSyncPending: false,
   });
 
+  const resetUndoState = () => ({
+    undoStack: [] as UndoSnapshot[],
+    redoStack: [] as UndoSnapshot[],
+  });
+
   const nextGenerationSyncRequestId = () => {
     generationSyncRequestSeq += 1;
     latestGenerationSyncRequestId = generationSyncRequestSeq;
@@ -409,12 +426,69 @@ export const useAppStore = create<AppState>((set, get) => {
     revision: 0,
     dirty: false,
     ...resetAnalysisState(),
+    ...resetUndoState(),
     analysisSettings: cloneAnalysisSettings(),
     activeWorkspacePanel: 'editor',
     editorMode: 'writing',
     viewScale: 'micro',
     analysisLayerOpen: false,
     statusMessage: '準備完了',
+
+  pushUndo: (snapshot) => {
+    set((state) => {
+      const next = [...state.undoStack, snapshot];
+      return {
+        undoStack: next.length > 50 ? next.slice(next.length - 50) : next,
+        redoStack: [],
+      };
+    });
+  },
+
+  undoWithCurrentSnapshot: (current) => {
+    const { undoStack } = get();
+    if (undoStack.length === 0) return null;
+    const target = undoStack[undoStack.length - 1];
+    set((state) => ({
+      undoStack: state.undoStack.slice(0, -1),
+      redoStack: [...state.redoStack, current],
+    }));
+    return target;
+  },
+
+  redoWithCurrentSnapshot: (current) => {
+    const { redoStack } = get();
+    if (redoStack.length === 0) return null;
+    const target = redoStack[redoStack.length - 1];
+    set((state) => ({
+      redoStack: state.redoStack.slice(0, -1),
+      undoStack: [...state.undoStack, current],
+    }));
+    return target;
+  },
+
+  restoreSnapshot: (snapshot) => {
+    const managed = isGenerationManagedDocument(snapshot.documentSnapshot, get().rootPath);
+    if (managed) {
+      nextGenerationSyncRequestId();
+    }
+    set({
+      document: snapshot.documentSnapshot,
+      dirty: true,
+      statusMessage: '編集中',
+      ...(managed
+        ? {
+            currentAnalysisGeneration: null,
+            analysisHistoriesByParagraphId: {},
+            selectedPatternIndexByParagraphId: {},
+            generationSyncPending: true,
+          }
+        : {}),
+    });
+  },
+
+  clearUndoStacks: () => {
+    set({ undoStack: [], redoStack: [] });
+  },
 
   hydrateProject: async (rootPath, source) => {
     try {
@@ -429,6 +503,7 @@ export const useAppStore = create<AppState>((set, get) => {
         revision: 0,
         dirty: false,
         ...resetAnalysisState(),
+        ...resetUndoState(),
         statusMessage:
           source === 'restore'
             ? `前回のフォルダを復元しました: ${rootPath}`
@@ -454,6 +529,7 @@ export const useAppStore = create<AppState>((set, get) => {
         revision: 0,
         dirty: false,
         ...resetAnalysisState(),
+        ...resetUndoState(),
         statusMessage:
           source === 'restore'
             ? `前回のフォルダを復元できませんでした: ${message}`
@@ -548,6 +624,7 @@ export const useAppStore = create<AppState>((set, get) => {
         revision: 0,
         dirty: false,
         ...resetAnalysisState(),
+        ...resetUndoState(),
         statusMessage: 'ドキュメントを作成しました',
       });
     } catch (error) {
@@ -573,6 +650,7 @@ export const useAppStore = create<AppState>((set, get) => {
           revision: 0,
           dirty: false,
           ...resetAnalysisState(),
+          ...resetUndoState(),
           statusMessage: '新規ファイルを作成しました',
         });
         return;
@@ -671,6 +749,7 @@ export const useAppStore = create<AppState>((set, get) => {
         revision: 0,
         dirty: false,
         ...resetAnalysisState(),
+        ...resetUndoState(),
         statusMessage: 'テキストをインポートしました',
       });
     } catch (error) {
@@ -707,6 +786,7 @@ export const useAppStore = create<AppState>((set, get) => {
         analysisHistoriesByParagraphId,
         selectedPatternIndexByParagraphId,
         generationSyncPending: false,
+        ...resetUndoState(),
         statusMessage: 'ドキュメントを読み込みました',
       });
     } catch {


### PR DESCRIPTION
## Summary

- `useAppStore` に `UndoSnapshot` 型・`undoStack`/`redoStack` ・5つのアクション（`pushUndo`, `undoWithCurrentSnapshot`, `redoWithCurrentSnapshot`, `restoreSnapshot`, `clearUndoStacks`）を追加
- `UndoPlugin`（新規）: Lexical の `HistoryPlugin` を置き換え。500ms debounce でテキスト編集をキャプチャし、`UNDO_COMMAND`/`REDO_COMMAND` でスナップショット復元。Ctrl+Z / Ctrl+Y のグローバルキーハンドラも内包
- `StructureStatePlugin`: `undo`/`redo` タグ付き更新を検知してスキップ（復元済み document の上書き防止）
- `ChapterCommandPlugin`: Ctrl+Enter・Enter（章ノード上）・Backspace 統合/格下げ の各操作前に `pushUndo` を追加し、explicit `editor.update()` に `{ tag: 'structural' }` を付与
- `ChapterDeletePlugin`: 章削除前に `pushUndo` を追加
- ドキュメント切り替え・新規作成・読み込み時はスタックをクリア

## 設計上のポイント

- Undo/Redo 実行時は `chapterNodeKeySetRef.current.clear()` でリセットし、`StructureStatePlugin` の fallback ロジックに nodeKey を再構築させる
- `StructureStatePlugin` は `undo`/`redo` タグの直後の更新も 1 回スキップして、nodeKey 再構築による意図しない `syncDocumentStructure` を防ぐ
- Backspace の格下げ・統合は `editor.update(() => {...}, { tag: 'structural' })` に移動し、UndoPlugin の debounce が二重 push しないよう制御

## Test plan

- [ ] テキスト入力後 500ms 待って Ctrl+Z → テキストが消える
- [ ] Ctrl+Enter で章追加 → Ctrl+Z で章が消える
- [ ] × ボタンで章削除 → Ctrl+Z で章が復元される
- [ ] 段落先頭で Backspace（統合）→ Ctrl+Z で段落が再分割される
- [ ] Ctrl+Z → Ctrl+Y でやり直しが効く
- [ ] 別ドキュメントを開いて戻る → Ctrl+Z が何も起きない（スタッククリア確認）

https://claude.ai/code/session_018FAsfE2d2dHe9uLvmFSmUj

---
_Generated by [Claude Code](https://claude.ai/code/session_018FAsfE2d2dHe9uLvmFSmUj)_