### PR TITLE
#60: parser.ts の無意味な代入を削除

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+[2026/05/02]Issue #60 parser.ts の冗長な代入を削除
+flushParagraph 内で `currentParagraphId.length === 0` 確認済みの早期 return 分岐にあった `currentParagraphId = ''` を削除した
+
 [2026/05/02]Issue #55 filesystem IPC パストラバーサル対策
 main 側 IPC でプロジェクトルート外のパス、symlink 経由の外部参照、不正な解析 ID を拒否する検証を追加し、回帰テストで確認した
 

--- a/packages/shared/src/lzl/parser.ts
+++ b/packages/shared/src/lzl/parser.ts
@@ -73,7 +73,6 @@ export function parseLzl(content: string): ParsedLzlDocument {
 
   const flushParagraph = () => {
     if (buffer.length === 0 && currentParagraphId.length === 0) {
-      currentParagraphId = '';
       return;
     }
 


### PR DESCRIPTION
Closes #60

## 概要

`packages/shared/src/lzl/parser.ts` の `flushParagraph` 内で、`currentParagraphId.length === 0` を確認済みの早期 return 分岐に存在した冗長な `currentParagraphId = ''` 代入を 1 行削除した。

該当分岐に到達する時点で `currentParagraphId` は既に空文字列であり、同じ値を再代入しても挙動は変わらない。

## 検証

| コマンド | 結果 |
|---|---|
| `pnpm --filter @litelizard/shared lint` | クリーン |
| `pnpm --filter @litelizard/shared test` | 42/42 通過（うち `parser.test.ts` 12/12） |
| `pnpm -w build` | 全パッケージ成功 |

`parser.test.ts` の 12 ケースが `flushParagraph` の挙動（空段落スキップ、段落マーカー切替、章境界での flush 等）を覆っており、削除前後で全テスト通過していることから、観測可能な挙動変化はない。

### 既存の workspace 全体 lint/test 失敗について

`pnpm -w lint` / `pnpm -w test` を実行すると以下の失敗が出るが、これらは **dev ブランチに既存** で本 PR とは無関係（`git stash` 後に `dev` 上で再現確認済み）:

- `apps/desktop`: `analysisStore.test.ts` の `beforeEach` 未使用、`preloadMockApi.js` の `structuredClone` 等（計 18 件）
- `apps/api`: `vitest` が `@litelizard/shared` のエントリ解決に失敗

Issue #60 のスコープは parser.ts の冗長代入削除に限定されているため、これらの既存問題は本 PR では修正していない（別 Issue 化すべき範疇）。

## セルフレビュー

- [x] Issue の受け入れ条件「無意味な代入を削除」を満たす（line 76 の 1 行削除）
- [x] 非ゴールに踏み込んでいない（parser.ts の他の箇所は触らず、関連リファクタも行わない）
- [x] 既存仕様を壊していない（parser.test.ts 12 ケース全通過、`packages/shared` 全 42 ケース通過）
- [x] 命名・型変更なし、コメント追加なし
- [x] テスト追加は不要（既存テストが該当ロジックを十分覆っている）

懸念事項なし。視覚確認も不要（パーサ内部ロジック修正）。

## CHANGELOG

`CHANGELOG.md` 先頭に以下を追記済み（`update-wbs-changelog` スキル経由）:

```
[2026/05/02]Issue #60 parser.ts の冗長な代入を削除
flushParagraph 内で `currentParagraphId.length === 0` 確認済みの早期 return 分岐にあった `currentParagraphId = ''` を削除した
```

WBS ID なしの GitHub Issue 単独管理タスクのため `docs/wbs.md` は更新していない。


---
_Generated by [Claude Code](https://claude.ai/code/session_013og4prY6ARwe8ctxwD8AvR)_